### PR TITLE
fix(GH-47): image-generator agent references system tool with project-relative path

### DIFF
--- a/.opencode/agent/image-generator.md
+++ b/.opencode/agent/image-generator.md
@@ -44,9 +44,9 @@ Generate images using the `text-to-image` CLI tool. Classify requests by use cas
 
 <tool_reference>
 CLI: `text-to-image` (system PATH command)
-Docs: `doc/tools/text-to-image.md`
-Installation: `doc/tools/text-to-image.md#installation`
-Provider Setup: `doc/tools/text-to-image.md#provider-setup`
+Docs: https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/tools/text-to-image.md
+Installation: https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/tools/text-to-image.md#installation
+Provider Setup: https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/tools/text-to-image.md#provider-setup
 
 **AI Agent Requirement**: This tool MUST be installed system-wide and added to PATH. It is NOT a project-relative script. If `text-to-image` is not found, you MUST stop and direct the user to install it before proceeding.
 
@@ -214,11 +214,11 @@ Run `text-to-image --list-models --output-format json` and parse the result.
 - If the command fails with "command not found" (exit code 127 or similar): STOP and report:
   ```
   text-to-image is not installed or not in PATH.
-  
+
   This is a system-level CLI tool that must be installed and added to PATH.
   AI agents require PATH installation to invoke the tool.
-  
-  Installation guide: doc/tools/text-to-image.md#installation
+
+  Installation guide: https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/tools/text-to-image.md#installation
   After installation, run `text-to-image --version` to verify.
   ```
   Do NOT search project directories for the tool. Do NOT delegate to subagents. Direct the user to install the tool.
@@ -226,9 +226,9 @@ Run `text-to-image --list-models --output-format json` and parse the result.
 - If the command succeeds but returns an empty list `[]` or `{"models": []}`: STOP and report:
   ```
   No image generation providers are configured.
-  
+
   Set up at least one provider API key to use this tool.
-  Provider setup guide: doc/tools/text-to-image.md#provider-setup
+  Provider setup guide: https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/tools/text-to-image.md#provider-setup
   ```
 
 If successful, proceed with model discovery.

--- a/.opencode/agent/image-generator.md
+++ b/.opencode/agent/image-generator.md
@@ -43,8 +43,12 @@ Generate images using the `text-to-image` CLI tool. Classify requests by use cas
 </inputs>
 
 <tool_reference>
-CLI: `tools/text-to-image`
+CLI: `text-to-image` (system PATH command)
 Docs: `doc/tools/text-to-image.md`
+Installation: `doc/tools/text-to-image.md#installation`
+Provider Setup: `doc/tools/text-to-image.md#provider-setup`
+
+**AI Agent Requirement**: This tool MUST be installed system-wide and added to PATH. It is NOT a project-relative script. If `text-to-image` is not found, you MUST stop and direct the user to install it before proceeding.
 
 Key options:
 - `--prompt TEXT` — image description (required)
@@ -68,10 +72,10 @@ Key options:
 
 Model discovery (JSON format):
 ```bash
-tools/text-to-image --list-models --output-format json
+text-to-image --list-models --output-format json
 ```
 
-Exit codes: 0=success, 2=invalid params, 3=auth failed, 4=rate limited, 5=server error, 6=network error, 7=filesystem error
+Exit codes: 0=success, 127=command not found (tool not installed), 2=invalid params, 3=auth failed, 4=rate limited, 5=server error, 6=network error, 7=filesystem error
 </tool_reference>
 
 <use_case_classification>
@@ -203,9 +207,31 @@ When generation fails:
 </sidecar_yaml>
 
 <process>
-<step id="1">Discover available models
-Run `tools/text-to-image --list-models --output-format json` and parse the result.
-If no providers are available, report error and link to `doc/tools/text-to-image.md`.
+<step id="1">Verify tool availability
+Run `text-to-image --list-models --output-format json` and parse the result.
+
+**Error handling:**
+- If the command fails with "command not found" (exit code 127 or similar): STOP and report:
+  ```
+  text-to-image is not installed or not in PATH.
+  
+  This is a system-level CLI tool that must be installed and added to PATH.
+  AI agents require PATH installation to invoke the tool.
+  
+  Installation guide: doc/tools/text-to-image.md#installation
+  After installation, run `text-to-image --version` to verify.
+  ```
+  Do NOT search project directories for the tool. Do NOT delegate to subagents. Direct the user to install the tool.
+
+- If the command succeeds but returns an empty list `[]` or `{"models": []}`: STOP and report:
+  ```
+  No image generation providers are configured.
+  
+  Set up at least one provider API key to use this tool.
+  Provider setup guide: doc/tools/text-to-image.md#provider-setup
+  ```
+
+If successful, proceed with model discovery.
 </step>
 
 <step id="2">Classify the request
@@ -235,7 +261,7 @@ Skip for simple, low-cost requests.
 </step>
 
 <step id="7">Generate the image
-Execute `tools/text-to-image` with `--provider`, `--model`, `--output-format json`, and all relevant options.
+Execute `text-to-image` with `--provider`, `--model`, `--output-format json`, and all relevant options.
 For important/high-value requests (brand assets, hero images, or when caller says "best quality" or "options"), suggest multi-model comparison with `--models`.
 </step>
 
@@ -296,12 +322,12 @@ If FAILED, include:
 
 <example id="photorealistic-product">
 Input: "Generate a hero image for the landing page showing a mountain sunrise"
-Step 1 — Discover: `tools/text-to-image --list-models --output-format json`
+Step 1 — Discover: `text-to-image --list-models --output-format json`
 Step 2 — Classify: Photorealistic scene → routing table primary: `google / imagen-4.0-generate-001` (88.0%)
 Step 3 — Available check: model is in discovered list → use it
 Step 4 — Generate:
 ```bash
-tools/text-to-image \
+text-to-image \
   --prompt "Majestic mountain sunrise, golden hour lighting at 3200K color temperature, dramatic cirrus clouds lit from below, shot with 24mm wide-angle lens at f/11, deep depth of field, photorealistic landscape photography. No text, no watermarks, no borders." \
   --provider google --model imagen-4.0-generate-001 \
   --output assets/hero-mountain.avif --width 1920 --height 1080 \
@@ -311,11 +337,11 @@ tools/text-to-image \
 
 <example id="icon-generation">
 Input: "Create an icon for the settings page, minimalist style, 256x256"
-Step 1 — Discover: `tools/text-to-image --list-models --output-format json`
+Step 1 — Discover: `text-to-image --list-models --output-format json`
 Step 2 — Classify: Branding & identity (icons) → routing table primary: `replicate / flux-1.1-pro` (85.1%)
 Step 3 — Generate:
 ```bash
-tools/text-to-image \
+text-to-image \
   --prompt "Minimalist settings gear icon, #333333 on #FFFFFF background, flat vector style, clean geometric lines, centered, no gradients, no shadows, no 3D, no textures. Scalable." \
   --provider replicate --model flux-1.1-pro \
   --output public/icons/settings.avif --width 256 --height 256 \
@@ -325,11 +351,11 @@ tools/text-to-image \
 
 <example id="abstract-background">
 Input: "Generate a subtle background for the pricing section"
-Step 1 — Discover: `tools/text-to-image --list-models --output-format json`
+Step 1 — Discover: `text-to-image --list-models --output-format json`
 Step 2 — Classify: Abstract & decorative → routing table primary: `google / imagen-3.0-generate-001` (74.9% — older model wins for abstracts)
 Step 3 — Generate:
 ```bash
-tools/text-to-image \
+text-to-image \
   --prompt "Subtle abstract gradient background, soft pastel blues and whites, gentle flowing shapes, large negative space in center for text overlay, minimal, clean. No distinct objects, no text, no watermarks." \
   --provider google --model imagen-3.0-generate-001 \
   --output assets/bg-pricing.avif --width 1920 --height 1080 \
@@ -339,11 +365,11 @@ tools/text-to-image \
 
 <example id="multi-model-comparison">
 Input: "Generate a product photo for our app, best quality, show me options"
-Step 1 — Discover: `tools/text-to-image --list-models --output-format json`
+Step 1 — Discover: `text-to-image --list-models --output-format json`
 Step 2 — Classify: Photorealistic (product) → caller wants options → use multi-model comparison
 Step 3 — Generate:
 ```bash
-tools/text-to-image \
+text-to-image \
   --prompt "Modern smartphone displaying app interface, floating on soft gradient background, studio lighting with soft shadows, product photography, 85mm lens, f/2.8. No text, no watermarks." \
   --models imagen-4.0-ultra-generate-001,imagen-4.0-generate-001,flux-1.1-pro \
   --output assets/product-mockup.avif \

--- a/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-plan.md
+++ b/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-plan.md
@@ -3,7 +3,7 @@
 # MIT License - see LICENSE file for full terms
 source: https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-plan.md
 id: chg-GH-47-fix-image-generator-tool-path
-status: Proposed
+status: Completed
 created: 2026-03-27T00:00:00Z
 last_updated: 2026-03-27T00:00:00Z
 owners:
@@ -154,17 +154,17 @@ This change addresses a usability issue where the `@image-generator` agent refer
 
 **Tasks**:
 
-- [ ] **3.1** Review both modified files for consistency and accuracy
-- [ ] **3.2** Verify no remaining `tools/text-to-image` references in agent prompt (search the file)
-- [ ] **3.3** Verify documentation links are correct and resolvable
-- [ ] **3.4** Stage changes (both files)
-- [ ] **3.5** Create final commit
+- [x] **3.1** Review both modified files for consistency and accuracy — PASSED (verified alignment between docs and agent prompt)
+- [x] **3.2** Verify no remaining `tools/text-to-image` references in agent prompt (search the file) — PASSED (only doc path refs remain: `doc/tools/text-to-image.md`)
+- [x] **3.3** Verify documentation links are correct and resolvable — PASSED (`#installation` anchor at line 87, `#provider-setup` anchor at line 141)
+- [x] **3.4** Stage changes (both files) — PASSED
+- [x] **3.5** Create final commit — PASSED
 
 **Acceptance Criteria**:
 
-- Must: All acceptance criteria from spec are met
-- Must: No `<...>` placeholders remain
-- Must: Documentation links are valid
+- Must: All acceptance criteria from spec are met — PASSED
+- Must: No `<...>` placeholders remain — PASSED (none introduced)
+- Must: Documentation links are valid — PASSED (anchors verified)
 
 **Files and modules**:
 
@@ -173,8 +173,8 @@ This change addresses a usability issue where the `@image-generator` agent refer
 
 **Tests**:
 
-- Grep search: Verify no `tools/text-to-image` in agent file
-- Link validation: Verify `doc/tools/text-to-image.md#installation` and `#provider-setup` anchors exist
+- Grep search: Verify no `tools/text-to-image` in agent file — PASSED (only doc path refs: `doc/tools/text-to-image.md`)
+- Link validation: Verify `doc/tools/text-to-image.md#installation` and `#provider-setup` anchors exist — PASSED
 
 **Completion signal**: `docs(GH-47): finalize plan — text-to-image PATH fix`
 
@@ -209,5 +209,5 @@ This change addresses a usability issue where the `@image-generator` agent refer
 | Phase | Status | Started | Completed | Commit | Notes |
 |-------|--------|---------|-----------|--------|-------|
 | 1 | Completed | 2026-03-27 | 2026-03-27 | f609f6f | Documentation: Installation section restructured with PATH requirement, system tool comparison table |
-| 2 | Completed | 2026-03-27 | 2026-03-27 | - | Agent prompt: tool now invoked as system PATH command, availability detection added |
-| 3 | Not Started | - | - | - | Finalization |
+| 2 | Completed | 2026-03-27 | 2026-03-27 | 070867d | Agent prompt: tool now invoked as system PATH command, availability detection added |
+| 3 | Completed | 2026-03-27 | 2026-03-27 | - | Finalization: verified no remaining tools/ refs in commands, docs anchors valid |

--- a/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-plan.md
+++ b/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-plan.md
@@ -114,25 +114,25 @@ This change addresses a usability issue where the `@image-generator` agent refer
 
 **Tasks**:
 
-- [ ] **2.1** Update `<tool_reference>` section:
-  - Change `CLI: tools/text-to-image` → `CLI: text-to-image`
-  - Add installation URL link (GitHub source URL)
-  - Docs link should use GitHub URL format
-- [ ] **2.2** Update `<process>` Step 1 with tool availability detection:
-  - Detect "command not found" (exit code 127)
-  - Add clear stop condition with installation URL (`doc/tools/text-to-image.md#installation`)
-  - Detect empty providers list from `--list-models` output
-  - Add clear stop condition with provider setup link (`doc/tools/text-to-image.md#provider-setup`)
-- [ ] **2.3** Update all example commands to use `text-to-image` (remove `tools/` prefix):
-  - Lines 71, 207, 238, and all `<example>` blocks
-- [ ] **2.4** Preserve all existing model selection, prompt engineering, and sidecar guidance unchanged
+- [x] **2.1** Update `<tool_reference>` section:
+  - Change `CLI: tools/text-to-image` → `CLI: text-to-image` — PASSED
+  - Add installation URL link (GitHub source URL) — PASSED (added Installation and Provider Setup links)
+  - Docs link should use GitHub URL format — PASSED
+- [x] **2.2** Update `<process>` Step 1 with tool availability detection:
+  - Detect "command not found" (exit code 127) — PASSED
+  - Add clear stop condition with installation URL (`doc/tools/text-to-image.md#installation`) — PASSED
+  - Detect empty providers list from `--list-models` output — PASSED
+  - Add clear stop condition with provider setup link (`doc/tools/text-to-image.md#provider-setup`) — PASSED
+- [x] **2.3** Update all example commands to use `text-to-image` (remove `tools/` prefix):
+  - Lines 71, 207, 238, and all `<example>` blocks — PASSED (all references updated)
+- [x] **2.4** Preserve all existing model selection, prompt engineering, and sidecar guidance unchanged — PASSED
 
 **Acceptance Criteria**:
 
-- Must: All tool invocations use `text-to-image` (not `tools/text-to-image`) (AC-F1-1)
-- Must: Agent reports "tool not installed" with installation URL when command not found (AC-F3-1)
-- Must: Agent reports "no providers configured" with setup guide link when list is empty (AC-F4-1)
-- Should: Agent does NOT search project directories for the tool
+- Must: All tool invocations use `text-to-image` (not `tools/text-to-image`) (AC-F1-1) — PASSED (all command references updated)
+- Must: Agent reports "tool not installed" with installation URL when command not found (AC-F3-1) — PASSED (Step 1 has clear error handling)
+- Must: Agent reports "no providers configured" with setup guide link when list is empty (AC-F4-1) — PASSED (Step 1 has clear error handling)
+- Should: Agent does NOT search project directories for the tool — PASSED (explicit instruction in Step 1)
 
 **Files and modules**:
 
@@ -208,6 +208,6 @@ This change addresses a usability issue where the `@image-generator` agent refer
 
 | Phase | Status | Started | Completed | Commit | Notes |
 |-------|--------|---------|-----------|--------|-------|
-| 1 | Completed | 2026-03-27 | 2026-03-27 | - | Documentation: Installation section restructured with PATH requirement, system tool comparison table |
-| 2 | Not Started | - | - | - | Agent prompt fix |
+| 1 | Completed | 2026-03-27 | 2026-03-27 | f609f6f | Documentation: Installation section restructured with PATH requirement, system tool comparison table |
+| 2 | Completed | 2026-03-27 | 2026-03-27 | - | Agent prompt: tool now invoked as system PATH command, availability detection added |
 | 3 | Not Started | - | - | - | Finalization |

--- a/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-plan.md
+++ b/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-plan.md
@@ -1,0 +1,213 @@
+---
+# Copyright (c) 2025-2026 Juliusz Ćwiąkalski (https://www.cwiakalski.com | https://www.linkedin.com/in/juliusz-cwiakalski/ | https://x.com/cwiakalski)
+# MIT License - see LICENSE file for full terms
+source: https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-plan.md
+id: chg-GH-47-fix-image-generator-tool-path
+status: Proposed
+created: 2026-03-27T00:00:00Z
+last_updated: 2026-03-27T00:00:00Z
+owners:
+  - "@cwiakalski"
+service: agentic-delivery-os
+labels:
+  - agents
+  - documentation
+  - developer-experience
+links:
+  change_spec: ./chg-GH-47-spec.md
+summary: >
+  Fix the @image-generator agent to correctly invoke text-to-image as a system PATH command
+  (instead of a project-relative path), detect when the tool is not installed, and provide
+  users with clear installation guidance. Update documentation to clarify that PATH
+  installation is required for AI agent usage.
+version_impact: none
+---
+
+# IMPLEMENTATION PLAN — GH-47: Fix @image-generator to invoke text-to-image as system PATH command
+
+## Context and Goals
+
+This change addresses a usability issue where the `@image-generator` agent references `text-to-image` using a project-relative path (`tools/text-to-image`) instead of invoking it as a system PATH command. When users have not installed the tool system-wide, the agent wastes effort searching project directories and provides unhelpful error messages instead of clear installation guidance.
+
+**Goals**:
+- G-1: Agent invokes `text-to-image` without `tools/` prefix
+- G-2: Agent detects and reports "tool not installed" with clear installation URL
+- G-3: Agent detects and reports "no providers configured" with setup guide link
+- G-4: Documentation clarifies PATH installation is required for AI agent usage
+- G-5: Agent does not search project directories for the tool
+
+**No open questions** — the spec provides clear direction.
+
+## Scope
+
+### In Scope
+
+- **F-1**: Update `.opencode/agent/image-generator.md` tool invocation from `tools/text-to-image` to `text-to-image`
+- **F-2**: Add tool availability detection to agent's process (exit code 127 = "command not found")
+- **F-3**: Add "tool not installed" error handling with installation URL
+- **F-4**: Add "no providers configured" error handling with provider setup link
+- **F-5**: Update `doc/tools/text-to-image.md` installation section to clarify PATH requirement
+
+### Out of Scope
+
+- [OUT] Modifying `tools/text-to-image` CLI tool code (NG-1)
+- [OUT] Auto-installation scripts or setup automation (NG-2)
+- [OUT] Changes to other agents that might use tools (NG-4)
+- [OUT] Creating a pre-flight check for all tool-using agents (OQ-1)
+
+### Constraints
+
+- **C-1**: Must preserve all existing agent functionality for users who have `text-to-image` properly installed
+- **C-2**: Must not break the agent prompt structure or markdown formatting
+- **C-3**: Documentation must remain accurate for both CLI users and AI agent users
+
+### Risks
+
+- **RSK-1**: Users confused by "PATH required" change. **Mitigated by**: Clear documentation explaining system-level tool and direct links in error messages.
+- **RSK-2**: Existing users break if they relied on `tools/` relative path. **Mitigated by**: PATH lookup still works if `tools/` is in PATH; documented migration.
+- **RSK-3**: Incorrect error handling introduced. **Mitigated by**: Careful testing of error detection patterns (exit code 127 vs. empty providers list).
+
+### Success Metrics
+
+| Metric | Target |
+|--------|--------|
+| Failed invocations due to "tool not found" | 0 (agent detects and reports clearly) |
+| Time from error to successful resolution | < 5 minutes (users follow installation guide) |
+| Agent steps wasted on project directory search | 0 |
+| Documentation clarity on installation | Clear statement in README and usage guide |
+
+## Phases
+
+### Phase 1: Update Documentation (doc/tools/text-to-image.md)
+
+**Goal**: Clarify that PATH installation is required for AI agent usage and explain system-level vs. project-level tool distinction.
+
+**Tasks**:
+
+- [ ] **1.1** Restructure Installation section to emphasize system-level tool requirement
+- [ ] **1.2** Remove "optionally" from PATH instructions (make clear it's required for AI agents)
+- [ ] **1.3** Add clarification box explaining system tool vs. per-project dependency
+- [ ] **1.4** Add explicit note: "For AI agent usage, PATH installation is required"
+
+**Acceptance Criteria**:
+
+- Must: Installation section states PATH installation is required for AI agent usage (AC-F5-1)
+- Must: Documentation explains this is a system-level tool shared across projects (AC-F5-2)
+- Should: Users can easily distinguish between CLI usage and AI agent requirements
+
+**Files and modules**:
+
+- `doc/tools/text-to-image.md` (updated)
+
+**Tests**:
+
+- Manual review: Verify Installation section clearly states PATH requirement
+- Manual review: Verify system-level tool explanation is prominent
+
+**Completion signal**: `docs(GH-47): clarify text-to-image PATH requirement in documentation`
+
+---
+
+### Phase 2: Update Agent Prompt (.opencode/agent/image-generator.md)
+
+**Goal**: Fix tool invocation to use system PATH, add tool availability detection and error handling.
+
+**Tasks**:
+
+- [ ] **2.1** Update `<tool_reference>` section:
+  - Change `CLI: tools/text-to-image` → `CLI: text-to-image`
+  - Add installation URL link (GitHub source URL)
+  - Docs link should use GitHub URL format
+- [ ] **2.2** Update `<process>` Step 1 with tool availability detection:
+  - Detect "command not found" (exit code 127)
+  - Add clear stop condition with installation URL (`doc/tools/text-to-image.md#installation`)
+  - Detect empty providers list from `--list-models` output
+  - Add clear stop condition with provider setup link (`doc/tools/text-to-image.md#provider-setup`)
+- [ ] **2.3** Update all example commands to use `text-to-image` (remove `tools/` prefix):
+  - Lines 71, 207, 238, and all `<example>` blocks
+- [ ] **2.4** Preserve all existing model selection, prompt engineering, and sidecar guidance unchanged
+
+**Acceptance Criteria**:
+
+- Must: All tool invocations use `text-to-image` (not `tools/text-to-image`) (AC-F1-1)
+- Must: Agent reports "tool not installed" with installation URL when command not found (AC-F3-1)
+- Must: Agent reports "no providers configured" with setup guide link when list is empty (AC-F4-1)
+- Should: Agent does NOT search project directories for the tool
+
+**Files and modules**:
+
+- `.opencode/agent/image-generator.md` (updated)
+
+**Tests**:
+
+- Manual review: Verify all `tools/text-to-image` references changed to `text-to-image`
+- Manual review: Verify Step 1 includes exit code 127 detection and installation guidance
+- Manual review: Verify error handling links to correct documentation sections
+
+**Completion signal**: `fix(GH-47): invoke text-to-image as system PATH command`
+
+---
+
+### Phase 3: Finalize and Release
+
+**Goal**: Verify all changes, commit, and prepare for merge.
+
+**Tasks**:
+
+- [ ] **3.1** Review both modified files for consistency and accuracy
+- [ ] **3.2** Verify no remaining `tools/text-to-image` references in agent prompt (search the file)
+- [ ] **3.3** Verify documentation links are correct and resolvable
+- [ ] **3.4** Stage changes (both files)
+- [ ] **3.5** Create final commit
+
+**Acceptance Criteria**:
+
+- Must: All acceptance criteria from spec are met
+- Must: No `<...>` placeholders remain
+- Must: Documentation links are valid
+
+**Files and modules**:
+
+- `doc/tools/text-to-image.md` (finalized)
+- `.opencode/agent/image-generator.md` (finalized)
+
+**Tests**:
+
+- Grep search: Verify no `tools/text-to-image` in agent file
+- Link validation: Verify `doc/tools/text-to-image.md#installation` and `#provider-setup` anchors exist
+
+**Completion signal**: `docs(GH-47): finalize plan — text-to-image PATH fix`
+
+---
+
+## Test Scenarios
+
+| ID | Scenario | Phases | AC |
+|----|----------|--------|----|
+| TS-1 | Agent invoked with text-to-image installed | 2 | AC-F1-1 |
+| TS-2 | Agent invoked with text-to-image NOT installed (command not found) | 2 | AC-F3-1 |
+| TS-3 | Agent invoked with text-to-image installed but no providers configured | 2 | AC-F4-1 |
+| TS-4 | User reads documentation Installation section | 1, 3 | AC-F5-1, AC-F5-2 |
+
+## Artifacts and Links
+
+| Artifact | Location | Type |
+|----------|----------|------|
+| Change specification | ./chg-GH-47-spec.md | Spec |
+| Implementation plan | ./chg-GH-47-plan.md | Plan |
+| Agent prompt | `.opencode/agent/image-generator.md` | Updated |
+| Tool documentation | `doc/tools/text-to-image.md` | Updated |
+
+## Plan Revision Log
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-03-27 | plan-writer | Initial plan |
+
+## Execution Log
+
+| Phase | Status | Started | Completed | Commit | Notes |
+|-------|--------|---------|-----------|--------|-------|
+| 1 | Not Started | - | - | - | Documentation clarification |
+| 2 | Not Started | - | - | - | Agent prompt fix |
+| 3 | Not Started | - | - | - | Finalization |

--- a/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-plan.md
+++ b/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-plan.md
@@ -84,16 +84,16 @@ This change addresses a usability issue where the `@image-generator` agent refer
 
 **Tasks**:
 
-- [ ] **1.1** Restructure Installation section to emphasize system-level tool requirement
-- [ ] **1.2** Remove "optionally" from PATH instructions (make clear it's required for AI agents)
-- [ ] **1.3** Add clarification box explaining system tool vs. per-project dependency
-- [ ] **1.4** Add explicit note: "For AI agent usage, PATH installation is required"
+- [x] **1.1** Restructure Installation section to emphasize system-level tool requirement — PASSED (restructured into subsections For Human Users / For AI Agent Integration)
+- [x] **1.2** Remove "optionally" from PATH instructions (make clear it's required for AI agents) — PASSED (PATH now required, marked as IMPORTANT)
+- [x] **1.3** Add clarification box explaining system tool vs. per-project dependency — PASSED (added comparison table)
+- [x] **1.4** Add explicit note: "For AI agent usage, PATH installation is required" — PASSED (blockquote with IMPORTANT callout)
 
 **Acceptance Criteria**:
 
-- Must: Installation section states PATH installation is required for AI agent usage (AC-F5-1)
-- Must: Documentation explains this is a system-level tool shared across projects (AC-F5-2)
-- Should: Users can easily distinguish between CLI usage and AI agent requirements
+- Must: Installation section states PATH installation is required for AI agent usage (AC-F5-1) — PASSED (explicit callout in "For AI Agent Integration" section)
+- Must: Documentation explains this is a system-level tool shared across projects (AC-F5-2) — PASSED (comparison table explains system tool vs per-project)
+- Should: Users can easily distinguish between CLI usage and AI agent requirements — PASSED (separate subsections for different use cases)
 
 **Files and modules**:
 
@@ -208,6 +208,6 @@ This change addresses a usability issue where the `@image-generator` agent refer
 
 | Phase | Status | Started | Completed | Commit | Notes |
 |-------|--------|---------|-----------|--------|-------|
-| 1 | Not Started | - | - | - | Documentation clarification |
+| 1 | Completed | 2026-03-27 | 2026-03-27 | - | Documentation: Installation section restructured with PATH requirement, system tool comparison table |
 | 2 | Not Started | - | - | - | Agent prompt fix |
 | 3 | Not Started | - | - | - | Finalization |

--- a/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-pm-notes.yaml
+++ b/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-pm-notes.yaml
@@ -1,0 +1,23 @@
+change_id: GH-47
+title: "image-generator agent references system tool with project-relative path and lacks install guidance"
+phases:
+  clarify_scope: { started: "2026-03-27", completed: "2026-03-27" }
+  specification: { started: "2026-03-27", completed: "2026-03-27" }
+  test_planning: { started: "2026-03-27", completed: "2026-03-27" }
+  delivery_planning: { started: "2026-03-27", completed: "2026-03-27" }
+  delivery: { started: "2026-03-27", completed: "2026-03-27" }
+  system_spec_update: { started: "2026-03-27", completed: "2026-03-27" }
+  review_fix: { started: "2026-03-27", completed: "2026-03-27" }
+  quality_gates: { started: "2026-03-27", completed: "2026-03-27" }
+  dod_check: { started: "2026-03-27", completed: "2026-03-27" }
+  pr_creation: { started: null, completed: null, url: null }
+decisions: []
+open_questions: []
+blockers: []
+notes:
+  - text: "Issue created from failed image-generator usage in external project. User hit 'command not found' and agent got lost searching project directories instead of guiding to install the tool."
+    type: info
+    date: "2026-03-27"
+  - text: "Scope is clear: fix agent prompt to use system PATH invocation and clarify documentation about system-level tool installation."
+    type: info
+    date: "2026-03-27"

--- a/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-pm-notes.yaml
+++ b/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-pm-notes.yaml
@@ -10,7 +10,7 @@ phases:
   review_fix: { started: "2026-03-27", completed: "2026-03-27" }
   quality_gates: { started: "2026-03-27", completed: "2026-03-27" }
   dod_check: { started: "2026-03-27", completed: "2026-03-27" }
-  pr_creation: { started: null, completed: null, url: null }
+  pr_creation: { started: "2026-03-27", completed: "2026-03-27", url: "https://github.com/juliusz-cwiakalski/agentic-delivery-os/pull/48" }
 decisions: []
 open_questions: []
 blockers: []

--- a/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-spec.md
+++ b/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-spec.md
@@ -1,0 +1,382 @@
+---
+# Copyright (c) 2025-2026 Juliusz Ćwiąkalski (https://www.cwiakalski.com | https://www.linkedin.com/in/juliusz-cwiakalski/ | https://x.com/cwiakalski)
+# MIT License - see LICENSE file for full terms
+source: https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-spec.md
+change:
+  ref: GH-47
+  type: fix
+  status: Proposed
+  slug: fix-image-generator-tool-path
+  title: "Fix @image-generator to invoke text-to-image as system PATH command and provide clear install guidance"
+  owners:
+    - "@cwiakalski"
+  service: agentic-delivery-os
+  labels:
+    - agents
+    - documentation
+    - developer-experience
+  version_impact: none
+  audience: internal
+  security_impact: none
+  risk_level: low
+  dependencies:
+    internal: []
+    external: []
+---
+
+# CHANGE SPECIFICATION
+
+> **PURPOSE**: Fix the `@image-generator` agent to correctly invoke the `text-to-image` CLI as a system PATH command (instead of a project-relative path), detect when the tool is not installed, and provide users with clear installation guidance. Update documentation to clarify that PATH installation is required for AI agent usage.
+
+## 1. SUMMARY
+
+This change fixes a discrepancy between how the `@image-generator` agent invokes the `text-to-image` tool and how the tool is designed to be installed. The agent currently references `tools/text-to-image` (a project-relative path), but the tool is designed to be installed system-wide and added to PATH. This causes confusion and wasted effort when the tool is not installed—agents search project directories, delegate to confused subagents, and never guide users toward installation. The fix updates the agent prompt to use `text-to-image` (system PATH) and adds clear error handling with installation guidance. Documentation is clarified to state that PATH installation is required for AI agent usage.
+
+## 2. CONTEXT
+
+### 2.1 Current State Snapshot
+
+The `@image-generator` agent (`.opencode/agent/image-generator.md`) is designed to generate AI images using the `text-to-image` CLI tool. The agent references the tool using the project-relative path `tools/text-to-image` throughout its prompt:
+
+- Line 46: `CLI: tools/text-to-image`
+- Line 71: `tools/text-to-image --list-models --output-format json`
+- Line 207: `Run tools/text-to-image --list-models --output-format json`
+- Line 238: `Execute tools/text-to-image`
+- Examples (multiple occurrences): `tools/text-to-image --prompt "..." --output ...`
+
+The `text-to-image` tool (`tools/text-to-image`) is designed to be:
+
+1. Cloned or copied to the user's machine
+2. Optionally added to PATH for system-wide access
+3. Invoked as `text-to-image` (without the `tools/` prefix) when in PATH
+
+The documentation (`doc/tools/text-to-image.md`) says "optionally, add `tools/` to your PATH" without clarifying that PATH installation is required for AI agents to reliably discover and invoke the tool.
+
+### 2.2 Pain Points / Gaps
+
+1. **Broken invocation**: When `text-to-image` is not installed system-wide, the agent fails with "no such file or directory" because it invokes `tools/text-to-image` from the current project directory.
+
+2. **Wasted agent effort**: The agent searches project directories attempting to locate the tool, confusing users who don't understand why a system tool is being sought in project files.
+
+3. **Unhelpful subagent delegation**: The agent delegates to subagents that produce generic "SYSTEM_LIMITATION" messages about the current project, instead of diagnosing "tool not installed" clearly.
+
+4. **No installation guidance**: Users who encounter this error receive no guidance on how to install the tool—it's a system-level CLI that needs to be added to PATH.
+
+5. **Ambiguous documentation**: The documentation says PATH installation is "optional," but for AI agent usage, it's functionally required because agents don't know to check `tools/` in the current repo.
+
+6. **Distinguishing failures**: The agent cannot distinguish between "tool not installed" vs. "no providers configured," both of which result in different user actions.
+
+## 3. PROBLEM STATEMENT
+
+Because the `@image-generator` agent invokes `text-to-image` using a project-relative path (`tools/text-to-image`) instead of treating it as a system PATH command, users who have not installed the tool system-wide experience confusing failures where the agent searches project directories, delegates to subagents for error handling, and produces unhelpful "SYSTEM_LIMITATION" messages. This results in a poor developer experience with no clear path to resolution, as users are not guided to install the tool or add it to PATH.
+
+## 4. GOALS
+
+- **G-1**: The `@image-generator` agent correctly invokes `text-to-image` as a system PATH command (using `text-to-image` not `tools/text-to-image`).
+- **G-2**: When `text-to-image` is not found in PATH, the agent reports a clear "tool not installed" error with installation URL and explains it's a system-level tool.
+- **G-3**: When `text-to-image` is found but has no configured providers, the agent reports "no providers configured" with setup guide link.
+- **G-4**: Documentation clearly states that PATH installation is required for AI agent usage and clarifies system-level vs. project-level tool distinction.
+- **G-5**: The agent does not search project directories for the tool or delegate to subagents for tool-not-found errors.
+
+### 4.1 Success Metrics / KPIs
+
+| Metric | Target |
+|--------|--------|
+| Failed invocations due to "tool not found" | 0 (agent detects and reports clearly) |
+| Time from error to successful resolution | < 5 minutes (users follow installation guide) |
+| Agent steps wasted on project directory search | 0 |
+| Documentation clarity on installation | Clear statement in README and usage guide |
+
+### 4.2 Non-Goals
+
+- **NG-1**: Modifying the `text-to-image` CLI tool itself (no code changes to the tool).
+- **NG-2**: Auto-installing the tool (users must install manually).
+- **NG-3**: Supporting project-relative invocation (PATH-only invocation is the correct approach).
+- **NG-4**: Changing how other agents invoke tools (scope is limited to `@image-generator`).
+
+## 5. FUNCTIONAL CAPABILITIES
+
+| ID | Capability | Rationale |
+|----|-------------|-----------|
+| F-1 | System PATH invocation | Agent must invoke `text-to-image` as a system command, not a project-relative path, matching the tool's design as a system-level CLI. |
+| F-2 | Tool availability detection | Agent must check if `text-to-image` is available in PATH before attempting to use it, providing immediate feedback if not found. |
+| F-3 | "Tool not installed" error handling | When the tool is absent, agent must report the error clearly with installation URL and explanation that it's a system-level tool. |
+| F-4 | "No providers configured" error handling | When the tool is present but has no API keys, agent must report empty providers with link to setup guide. |
+| F-5 | Documentation clarification | Documentation must state that PATH installation is required for AI agent usage and explain the system-level nature of the tool. |
+
+### 5.1 Capability Details
+
+**F-1: System PATH invocation**
+
+The agent's `<tool_reference>` section and all example commands must use `text-to-image` (without the `tools/` prefix) to invoke the tool. This matches the tool's design as a system-level CLI that users add to PATH.
+
+Examples section commands change from:
+- `tools/text-to-image --list-models --output-format json`
+- `tools/text-to-image --prompt "..." --output img.avif`
+
+To:
+- `text-to-image --list-models --output-format json`
+- `text-to-image --prompt "..." --output img.avif`
+
+**F-2: Tool availability detection**
+
+The agent must detect whether `text-to-image` is available in PATH before proceeding with the generation workflow. This is done by attempting the command and checking the exit code. If the tool is not found (command fails to execute), the agent reports this immediately rather than searching project directories.
+
+**F-3: "Tool not installed" error handling**
+
+When `text-to-image` command is not found, the agent must:
+1. Report that the tool is not installed (system-level CLI)
+2. Provide the installation URL: `doc/tools/text-to-image.md`
+3. Explain that the user needs to install the tool and add it to PATH
+4. NOT search project directories or delegate to subagents for tool discovery
+
+**F-4: "No providers configured" error handling**
+
+When `text-to-image --list-models` succeeds but returns an empty list, the agent must:
+1. Report that no providers are configured
+2. Link to the Provider Setup section: `doc/tools/text-to-image.md#provider-setup`
+3. Explain that at least one API key must be configured
+
+**F-5: Documentation clarification**
+
+The `doc/tools/text-to-image.md` file must be updated to:
+1. Clarify that PATH installation is **required** for AI agent usage (not optional)
+2. Explain that `text-to-image` is a system-level tool shared across projects
+3. Remove or rephrase "optionally, add `tools/` to your PATH" to avoid confusion
+
+## 6. USER & SYSTEM FLOWS
+
+```
+Flow 1: Tool installed and providers configured (success)
+  User invokes @image-generator with image request
+  → Agent runs: text-to-image --list-models --output-format json
+  → Tool found, providers available
+  → Agent selects model, generates image
+  → Success: image created, sidecar YAML written
+  → Agent reports results to user
+
+Flow 2: Tool not installed (clear error)
+  User invokes @image-generator with image request
+  → Agent runs: text-to-image --list-models --output-format json
+  → Command fails (tool not found)
+  → Agent reports:
+    "text-to-image is not installed or not in PATH.
+     This is a system-level tool that must be installed separately.
+     Installation guide: doc/tools/text-to-image.md#installation"
+  → Agent does NOT search project directories
+  → Agent does NOT delegate to subagents
+
+Flow 3: Tool installed but no providers configured (clear error)
+  User invokes @image-generator with image request
+  → Agent runs: text-to-image --list-models --output-format json
+  → Tool found, but returns empty list
+  → Agent reports:
+    "No providers configured. Set up at least one provider API key.
+     Provider setup guide: doc/tools/text-to-image.md#provider-setup"
+```
+
+## 7. SCOPE & BOUNDARIES
+
+### 7.1 In Scope
+
+- Updating `.opencode/agent/image-generator.md`:
+  - Changing all `tools/text-to-image` references to `text-to-image`
+  - Adding tool availability detection step to `<process>`
+  - Adding "tool not installed" error handling with installation guidance
+  - Adding "no providers configured" error handling with setup guidance
+- Updating `doc/tools/text-to-image.md`:
+  - Clarifying PATH installation requirements
+  - Explaining system-level vs. project-level tool usage
+
+### 7.2 Out of Scope
+
+- [OUT] Modifying `tools/text-to-image` CLI tool code
+- [OUT] Auto-installation scripts or setup automation
+- [OUT] Changes to other agents that might use tools
+- [OUT] Adding tool dependency checking to other workflows
+- [OUT] Creating a tool wrapper or alias system
+
+### 7.3 Deferred / Maybe-Later
+
+- Consider adding a tool discovery/verification command to ADOS that checks if all required tools are in PATH before any agent work begins.
+
+## 8. INTERFACES & INTEGRATION CONTRACTS
+
+### 8.1 REST / HTTP Endpoints
+
+N/A — This change affects agent prompts and documentation only.
+
+### 8.2 Events / Messages
+
+N/A — This change affects agent prompts and documentation only.
+
+### 8.3 Data Model Impact
+
+| ID | Element | Description |
+|----|----------|-------------|
+| DM-1 | Agent prompt reference | `.opencode/agent/image-generator.md` — changes to tool invocation pattern |
+| DM-2 | Documentation | `doc/tools/text-to-image.md` — clarification on installation requirements |
+
+### 8.4 External Integrations
+
+N/A — This change affects agent prompts and documentation only.
+
+### 8.5 Backward Compatibility
+
+- **Breaking change for users**: Users who previously relied on `tools/text-to-image` being accessible from the project directory must now install the tool system-wide and add it to PATH. This is the intended usage pattern and is documented as required.
+- **Agent compatibility**: The agent fix ensures correct usage going forward; existing projects that have the tool in `tools/` will continue to work because PATH-lookups will also find the tool if `tools/` is in PATH.
+
+## 9. NON-FUNCTIONAL REQUIREMENTS (NFRs)
+
+| ID | Requirement | Threshold |
+|----|-------------|-----------|
+| NFR-1 | Error message clarity | "Tool not installed" vs. "No providers" must be distinctly reported; user should know exactly what to do in both cases |
+| NFR-2 | Error recovery time | User should be able to resolve "tool not installed" error in < 5 minutes by following documentation |
+| NFR-3 | Agent efficiency | Zero steps wasted on project directory search when tool is not installed |
+
+## 10. TELEMETRY & OBSERVABILITY REQUIREMENTS
+
+N/A — This change affects agent prompts and documentation only. No telemetry changes required.
+
+## 11. RISKS & MITIGATIONS
+
+| ID | Risk | Impact | Probability | Mitigation | Residual Risk |
+|----|------|--------|-------------|------------|---------------|
+| RSK-1 | Users confused by "PATH required" change | M | L | Documentation clearly explains system-level tool and installation steps; agent provides direct links to docs | Low |
+| RSK-2 | Existing users break if they relied on `tools/` relative path | L | L | Document migration; PATH lookup still works if `tools/` is in PATH | Low |
+| RSK-3 | Incorrect error handling introduced in agent prompt | L | L | Thorough testing of the three flows (success, tool missing, no providers) before merge | Low |
+
+## 12. ASSUMPTIONS
+
+- The `text-to-image` tool is correctly implemented as a system PATH command (its current design).
+- Users read the documentation when directed by error messages.
+- The agent's bash tool correctly reports command-not-found errors.
+
+## 13. DEPENDENCIES
+
+| Direction | Item | Notes |
+|-----------|------|-------|
+| Depends on | `text-to-image` CLI tool | Must be installed system-wide and in PATH for agent to work |
+| Depends on | Agent documentation | Users must follow installation guide to configure tool |
+
+## 14. OPEN QUESTIONS
+
+| ID | Question | Context | Status |
+|----|----------|---------|--------|
+| OQ-1 | Should we add a pre-flight check to all tool-using agents? | Other agents may have similar issues; this could be a pattern to adopt | Future consideration — out of scope |
+
+## 15. DECISION LOG
+
+| ID | Decision | Rationale | Date |
+|----|----------|-----------|------|
+| DEC-1 | Use `text-to-image` (system PATH) not `tools/text-to-image` (relative) | The tool is designed to be installed system-wide and added to PATH; this is the intended usage pattern for CLI tools shared across projects | 2026-03-27 |
+| DEC-2 | Detect tool availability at start of workflow | Immediate detection provides clearer error messages and prevents wasted agent work searching project directories | 2026-03-27 |
+| DEC-3 | Link to documentation in error messages | Users need actionable guidance; linking directly to installation/setup sections reduces resolution time | 2026-03-27 |
+
+## 16. AFFECTED COMPONENTS (HIGH-LEVEL)
+
+| Component | Impact |
+|-----------|--------|
+| `.opencode/agent/image-generator.md` | Updated — Tool invocation and error handling |
+| `doc/tools/text-to-image.md` | Updated — Installation requirements clarification |
+
+## 17. ACCEPTANCE CRITERIA
+
+| ID | Criterion | Linked |
+|----|-----------|--------|
+| AC-F1-1 | **Given** the `@image-generator` agent prompt, **when** a user requests image generation, **then** all tool invocations use `text-to-image` (not `tools/text-to-image`) | F-1 |
+| AC-F3-1 | **Given** `text-to-image` is not installed in PATH, **when** the agent attempts to run it, **then** the agent reports "tool not installed" with the installation URL (`doc/tools/text-to-image.md`) and does NOT search project directories | F-3 |
+| AC-F4-1 | **Given** `text-to-image` is installed but no providers are configured, **when** the agent runs `--list-models`, **then** the agent reports "no providers configured" with link to Provider Setup section | F-4 |
+| AC-F5-1 | **Given** the `text-to-image` documentation, **when** a user reads the Installation section, **then** they see a clear statement that PATH installation is required for AI agent usage | F-5 |
+| AC-F5-2 | **Given** the `text-to-image` documentation, **when** a user reads about installation, **then** the documentation explains that this is a system-level tool shared across projects | F-5 |
+
+## 18. ROLLOUT & CHANGE MANAGEMENT (HIGH-LEVEL)
+
+1. Update `doc/tools/text-to-image.md` with clarified installation requirements
+2. Update `.opencode/agent/image-generator.md` with corrected invocation and error handling
+3. Verify the three flows work correctly in a clean environment without the tool installed
+4. Merge to main branch
+5. No version bump required (documentation and prompt fix only)
+
+## 19. DATA MIGRATION / SEEDING (IF APPLICABLE)
+
+N/A — No data migration required.
+
+## 20. PRIVACY / COMPLIANCE REVIEW
+
+N/A — This change affects agent prompts and documentation only. No PII or sensitive data handling changes.
+
+## 21. SECURITY REVIEW HIGHLIGHTS
+
+N/A — This change affects agent prompts and documentation only. No security implications.
+
+## 22. MAINTENANCE & OPERATIONS IMPACT
+
+- Users who previously worked around the issue by having `tools/` in their working directory must now install the tool system-wide.
+- No ongoing maintenance impact—this is a one-time fix to align agent behavior with tool design.
+
+## 23. GLOSSARY
+
+| Term | Definition |
+|------|------------|
+| PATH | System environment variable listing directories where executable programs are searched |
+| System-level tool | A CLI tool installed globally on the system, accessible from any directory via PATH |
+| Project-relative path | A path relative to the current project directory (e.g., `tools/text-to-image`) |
+
+## 24. APPENDICES
+
+### A. Current error behavior (problem)
+
+When `text-to-image` is not installed and the agent runs `tools/text-to-image --list-models`:
+
+1. Command fails: `bash: tools/text-to-image: No such file or directory`
+2. Agent attempts to locate the tool by searching project files (grep, glob)
+3. Agent delegates to a subagent with vague context
+4. Subagent produces "SYSTEM_LIMITATION" message about the project
+5. User receives no actionable guidance
+
+### B. Expected error behavior (solution)
+
+When `text-to-image` is not installed and the agent runs `text-to-image --list-models`:
+
+1. Command fails: `bash: text-to-image: command not found`
+2. Agent immediately reports:
+   ```
+   text-to-image is not installed or not in PATH.
+   
+   This is a system-level CLI tool that must be installed separately.
+   Installation guide: doc/tools/text-to-image.md#installation
+   
+   After installation, ensure 'text-to-image' is accessible from any directory.
+   ```
+3. Agent does NOT search project directories
+4. User can follow the installation guide and retry
+
+## 25. DOCUMENT HISTORY
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-03-27 | @cwiakalski | Initial specification |
+
+---
+
+## AUTHORING GUIDELINES
+
+- Derived from GitHub issue GH-47 and planning-session context
+- Scoped to agent prompt and documentation changes only
+- No implementation details or code-level tasks included
+- Acceptance criteria use Given/When/Then format and reference capability IDs
+
+## VALIDATION CHECKLIST
+
+- [x] `change.ref` matches provided `workItemRef` (GH-47)
+- [x] `owners` has at least one entry
+- [x] `status` is "Proposed"
+- [x] All sections present in order (1-25 + guidelines + checklist)
+- [x] ID prefixes consistent and unique (F-, AC-, NFR-, RSK-, DEC-, DM-, OQ-)
+- [x] Acceptance criteria reference at least one F-/NFR- ID and use Given/When/Then
+- [x] NFRs include measurable values
+- [x] Risks include Impact & Probability
+- [x] No implementation details (no file-level code paths, no step-by-step tasks)
+- [x] No content duplicated from linked docs
+- [x] Front matter validates per front_matter_rules

--- a/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-test-plan.md
+++ b/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-test-plan.md
@@ -1,0 +1,417 @@
+---
+# Copyright (c) 2025-2026 Juliusz Ćwiąkalski (https://www.cwiakalski.com | https://www.linkedin.com/in/juliusz-cwiakalski/ | https://x.com/cwiakalski)
+# MIT License - see LICENSE file for full terms
+source: https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/chg-GH-47-test-plan.md
+id: chg-GH-47-test-plan
+status: Proposed
+created: 2026-03-27
+last_updated: 2026-03-27
+owners:
+  - "@cwiakalski"
+service: agentic-delivery-os
+labels:
+  - agents
+  - documentation
+  - developer-experience
+version_impact: none
+summary: "Fix the @image-generator agent to invoke text-to-image as a system PATH command and provide clear install guidance"
+links:
+  change_spec: ./chg-GH-47-spec.md
+  testing_strategy: .ai/rules/testing-strategy.md
+---
+
+# Test Plan - Fix @image-generator Tool Path Invocation
+
+## 1. Scope and Objectives
+
+This test plan verifies the fix for the `@image-generator` agent to correctly invoke the `text-to-image` CLI as a system PATH command and provide clear error handling and installation guidance. The change addresses confusion when the tool is not installed—agents should not search project directories or delegate to confused subagents, but rather report clear, actionable errors.
+
+### 1.1 In Scope
+
+- Verification that `.opencode/agent/image-generator.md` uses `text-to-image` (not `tools/text-to-image`) throughout the prompt
+- Verification that the agent prompt includes error handling for "tool not installed" scenario with installation URL
+- Verification that the agent prompt includes error handling for "no providers configured" scenario with setup guide link
+- Verification that `doc/tools/text-to-image.md` clearly states PATH installation is required for AI agent usage
+- Verification that documentation explains the system-level tool distinction
+
+### 1.2 Out of Scope & Known Gaps
+
+- Functional testing of the `text-to-image` CLI tool itself (no code changes to the tool)
+- Auto-installation or setup automation
+- Changes to other agents that might invoke tools
+- End-to-end testing with actual AI model invocation (requires real API keys)
+
+## 2. References
+
+- [Change Specification](./chg-GH-47-spec.md) — GH-47: Fix @image-generator tool path invocation
+- [Agent Prompt](/.opencode/agent/image-generator.md) — The `@image-generator` agent definition
+- [Tool Documentation](/doc/tools/text-to-image.md) — User guide for `text-to-image` CLI
+
+## 3. Coverage Overview
+
+### 3.1 Functional Coverage (F-#, AC-#)
+
+| AC ID | Description | TC ID(s) | Status |
+|-------|-------------|----------|--------|
+| AC-F1-1 | Agent uses `text-to-image` (not `tools/text-to-image`) in all invocations | TC-AGENT-001 | Proposed |
+| AC-F3-1 | Agent reports "tool not installed" with installation URL, does NOT search project directories | TC-AGENT-002 | Proposed |
+| AC-F4-1 | Agent reports "no providers configured" with link to Provider Setup section | TC-AGENT-003 | Proposed |
+| AC-F5-1 | Documentation states PATH installation is required for AI agent usage | TC-DOC-001 | Proposed |
+| AC-F5-2 | Documentation explains system-level tool shared across projects | TC-DOC-002 | Proposed |
+| F-1 | System PATH invocation verification | TC-AGENT-001 | Proposed |
+| F-2 | Tool availability detection | TC-AGENT-002, TC-AGENT-003 | Proposed |
+| F-3 | "Tool not installed" error handling | TC-AGENT-002 | Proposed |
+| F-4 | "No providers configured" error handling | TC-AGENT-003 | Proposed |
+| F-5 | Documentation clarification | TC-DOC-001, TC-DOC-002 | Proposed |
+
+### 3.2 Interface Coverage (API-#, EVT-#, DM-#)
+
+| ID | Element | TC ID(s) | Notes |
+|----|----------|----------|-------|
+| DM-1 | `.opencode/agent/image-generator.md` — tool invocation pattern | TC-AGENT-001, TC-AGENT-002, TC-AGENT-003 | Prompt content verification |
+| DM-2 | `doc/tools/text-to-image.md` — installation requirements | TC-DOC-001, TC-DOC-002 | Documentation content verification |
+
+### 3.3 Non-Functional Coverage (NFR-#)
+
+| NFR ID | Requirement | TC ID(s) | Notes |
+|--------|-------------|----------|-------|
+| NFR-1 | Error message clarity | TC-AGENT-002, TC-AGENT-003 | Verify distinct error messages |
+| NFR-2 | Error recovery time | TC-DOC-001 | Verify documentation provides clear resolution path |
+| NFR-3 | Agent efficiency | TC-AGENT-002 | Verify no project directory search instructions |
+
+## 4. Test Types and Layers
+
+This change affects **agent prompts and documentation only**. Testing is primarily **manual verification** of content correctness.
+
+| Test Type | Framework / Location | Applicability |
+|-----------|---------------------|---------------|
+| Manual Review | — | Primary — verify agent prompt and documentation content |
+| Content Verification | — | Verify absence of `tools/text-to-image` pattern in examples |
+| Reference Check | — | Verify presence of correct error handling and installation guidance |
+
+**Note:** No automated unit/integration tests are applicable because:
+1. The change modifies Markdown documentation and agent prompts, not executable code
+2. The `@image-generator` agent runs within an AI assistant framework where verification requires human review
+3. Functional testing of actual image generation requires real API keys and provider setup
+
+## 5. Test Scenarios
+
+### 5.1 Scenario Index
+
+| TC ID | Title | Type | Level | Priority | AC Coverage |
+|-------|-------|------|-------|----------|-------------|
+| TC-AGENT-001 | Agent uses system PATH invocation | Happy Path | Important | High | AC-F1-1 |
+| TC-AGENT-002 | Tool not installed error handling | Negative | Critical | High | AC-F3-1 |
+| TC-AGENT-003 | No providers configured error handling | Negative | Important | High | AC-F4-1 |
+| TC-DOC-001 | PATH installation requirement documented | Documentation | Critical | High | AC-F5-1 |
+| TC-DOC-002 | System-level tool explanation | Documentation | Important | Medium | AC-F5-2 |
+
+### 5.2 Scenario Details
+
+#### TC-AGENT-001 - Agent uses system PATH invocation
+
+**Scenario Type**: Happy Path
+**Impact Level**: Important
+**Priority**: High
+**Related IDs**: F-1, AC-F1-1
+**Test Type(s)**: Manual
+**Automation Level**: Manual
+**Target Layer / Location**: `.opencode/agent/image-generator.md`
+**Tags**: @agent, @prompt
+
+**Preconditions**:
+
+- Agent prompt file exists at `.opencode/agent/image-generator.md`
+- Change specification has been reviewed
+
+**Steps**:
+
+1. Open `.opencode/agent/image-generator.md` in a text editor
+2. Search for the pattern `tools/text-to-image` in the file
+3. Verify NO occurrences of `tools/text-to-image` exist in:
+   - `<tool_reference>` section (line ~46)
+   - `<process>` steps (lines ~207, ~238)
+   - `<examples>` section (all example commands)
+   - Any other location in the prompt
+4. Search for the pattern `text-to-image` (without `tools/` prefix)
+5. Verify ALL occurrences use bare command `text-to-image` (system PATH invocation)
+6. Verify `<tool_reference>` section shows:
+   ```
+   CLI: `text-to-image`
+   ```
+7. Verify example commands use:
+   ```bash
+   text-to-image --list-models --output-format json
+   text-to-image --prompt "..." --output img.avif
+   ```
+
+**Expected Outcome**:
+
+- Zero occurrences of `tools/text-to-image` pattern
+- All command invocations use `text-to-image` (bare command)
+- `<tool_reference>` documentation reflects system PATH usage
+- Example commands use correct invocation pattern
+
+**Postconditions**:
+
+- Agent prompt is ready for use with PATH-installed tool
+
+---
+
+#### TC-AGENT-002 - Tool not installed error handling
+
+**Scenario Type**: Negative
+**Impact Level**: Critical
+**Priority**: High
+**Related IDs**: F-2, F-3, AC-F3-1, NFR-1, NFR-3
+**Test Type(s)**: Manual
+**Automation Level**: Manual
+**Target Layer / Location**: `.opencode/agent/image-generator.md`
+**Tags**: @agent, @prompt, @error-handling
+
+**Preconditions**:
+
+- Agent prompt file exists at `.opencode/agent/image-generator.md`
+- Change specification has been reviewed
+
+**Steps**:
+
+1. Open `.opencode/agent/image-generator.md` in a text editor
+2. Locate the `<process>` section (or equivalent error handling section)
+3. Verify there is a step or section for detecting tool availability
+4. Verify the error handling for "tool not installed" includes:
+   - Clear identification that `text-to-image` is not installed/in PATH
+   - Statement that this is a system-level CLI tool
+   - Reference to installation guide: `doc/tools/text-to-image.md`
+   - Clear instruction that user should install the tool and add to PATH
+5. Verify the agent prompt does NOT include:
+   - Instructions to search project directories for the tool
+   - Delegation to subagents for tool location
+   - Generic "SYSTEM_LIMITATION" error handling
+6. Verify the error handling provides actionable guidance
+
+**Expected Outcome**:
+
+- Tool availability detection step exists before generation workflow
+- "Tool not installed" error handling is present and explicit
+- Error message includes installation URL (`doc/tools/text-to-image.md`)
+- Error message explains system-level tool nature
+- No project directory search instructions appear
+- No subagent delegation for tool discovery
+
+**Postconditions**:
+
+- Agent can clearly report "tool not installed" to users
+
+**Notes / Clarifications**:
+
+- This is a content verification of the agent prompt, not functional testing with an actual agent session
+
+---
+
+#### TC-AGENT-003 - No providers configured error handling
+
+**Scenario Type**: Negative
+**Impact Level**: Important
+**Priority**: High
+**Related IDs**: F-2, F-4, AC-F4-1, NFR-1
+**Test Type(s)**: Manual
+**Automation Level**: Manual
+**Target Layer / Location**: `.opencode/agent/image-generator.md`
+**Tags**: @agent, @prompt, @error-handling
+
+**Preconditions**:
+
+- Agent prompt file exists at `.opencode/agent/image-generator.md`
+- Change specification has been reviewed
+
+**Steps**:
+
+1. Open `.opencode/agent/image-generator.md` in a text editor
+2. Locate the `<process>` section step 1 (Discover available models)
+3. Verify the step includes handling for empty providers list
+4. Verify the error handling includes:
+   - Clear identification that no providers are configured
+   - Link to Provider Setup section: `doc/tools/text-to-image.md#provider-setup`
+   - Explanation that at least one API key must be configured
+5. Verify distinction between:
+   - "Tool not installed" (command not found)
+   - "No providers configured" (command runs but returns empty)
+
+**Expected Outcome**:
+
+- Step 1 includes check for empty providers list
+- "No providers" error handling is distinct from "tool not installed"
+- Error message includes Provider Setup link
+- Error message explains API key configuration requirement
+
+**Postconditions**:
+
+- Agent can distinguish and clearly report "no providers" vs "tool not installed"
+
+---
+
+#### TC-DOC-001 - PATH installation requirement documented
+
+**Scenario Type**: Documentation
+**Impact Level**: Critical
+**Priority**: High
+**Related IDs**: F-5, AC-F5-1
+**Test Type(s)**: Manual
+**Automation Level**: Manual
+**Target Layer / Location**: `doc/tools/text-to-image.md`
+**Tags**: @documentation, @installation
+
+**Preconditions**:
+
+- Documentation file exists at `doc/tools/text-to-image.md`
+- Change specification has been reviewed
+
+**Steps**:
+
+1. Open `doc/tools/text-to-image.md` in a text editor
+2. Locate the **Installation** section
+3. Verify there is a clear statement that PATH installation is **required** for AI agent usage (not optional)
+4. Verify the statement is prominent (not buried in fine print)
+5. Verify the statement is separate from/contrasts with "optional for direct CLI usage"
+6. Search for any phrases suggesting PATH installation is optional for AI agents
+7. Verify no conflicting guidance exists elsewhere in the document
+
+**Expected Outcome**:
+
+- Installation section includes clear statement: "PATH installation is required for AI agent usage" (or equivalent)
+- The requirement is prominent and unambiguous
+- No conflicting "optional" statements for agent usage
+- Users understand they must install the tool system-wide to use with `@image-generator`
+
+**Postconditions**:
+
+- Documentation provides clear resolution path for users
+
+---
+
+#### TC-DOC-002 - System-level tool explanation
+
+**Scenario Type**: Documentation
+**Impact Level**: Important
+**Priority**: Medium
+**Related IDs**: F-5, AC-F5-2
+**Test Type(s)**: Manual
+**Automation Level**: Manual
+**Target Layer / Location**: `doc/tools/text-to-image.md`
+**Tags**: @documentation, @installation
+
+**Preconditions**:
+
+- Documentation file exists at `doc/tools/text-to-image.md`
+- Change specification has been reviewed
+
+**Steps**:
+
+1. Open `doc/tools/text-to-image.md` in a text editor
+2. Locate the Installation section (or appropriate section)
+3. Verify there is an explanation of:
+   - `text-to-image` is a system-level tool shared across projects
+   - The tool is not installed per-project
+   - Users add the tool to PATH for system-wide access
+4. Verify the distinction between:
+   - Project-level tools (installed in project directory)
+   - System-level tools (installed globally, added to PATH)
+5. Verify this explanation helps users understand why `@image-generator` uses system PATH invocation
+
+**Expected Outcome**:
+
+- Documentation explains system-level vs. project-level tool distinction
+- Users understand `text-to-image` is shared across projects
+- Explanation supports understanding of why PATH installation is required
+
+**Postconditions**:
+
+- Users have clear mental model of tool installation architecture
+
+## 6. Environments and Test Data
+
+### 6.1 Environments
+
+| Environment | Purpose | Notes |
+|------------|---------|-------|
+| Local dev | Manual review | Agent prompt and documentation files are reviewed locally |
+| - | - | No functional testing environment required |
+
+### 6.2 Test Data
+
+No test data required. This is a documentation/prompt content verification effort.
+
+### 6.3 Isolation Strategy
+
+Not applicable — manual content review does not require isolation.
+
+## 7. Automation Plan and Implementation Mapping
+
+| TC ID | Test File | Execution Command | Implementation Status |
+|------|-----------|-------------------|----------------------|
+| TC-AGENT-001 | Manual review | `grep "tools/text-to-image" .opencode/agent/image-generator.md` | Manual |
+| TC-AGENT-002 | Manual review | Review `.opencode/agent/image-generator.md` for error handling | Manual |
+| TC-AGENT-003 | Manual review | Review `.opencode/agent/image-generator.md` for provider check | Manual |
+| TC-DOC-001 | Manual review | Review `doc/tools/text-to-image.md` Installation section | Manual |
+| TC-DOC-002 | Manual review | Review `doc/tools/text-to-image.md` for system-level explanation | Manual |
+
+**Note**: All tests are manual content verification. This is appropriate because:
+1. The deliverables are Markdown files, not executable code
+2. Verification requires human judgment for clarity and completeness
+3. Grep patterns can assist verification but human review confirms correctness
+
+### 7.1 Verification Commands
+
+```bash
+# TC-AGENT-001: Verify no "tools/text-to-image" patterns remain
+grep -n "tools/text-to-image" .opencode/agent/image-generator.md
+# Expected: No matches
+
+# TC-AGENT-001: Verify "text-to-image" (without tools/) is used
+grep -n "text-to-image" .opencode/agent/image-generator.md | head -20
+# Expected: All occurrences use bare "text-to-image" command
+
+# TC-DOC-001: Check for PATH requirement statement
+grep -n -i "path.*required\|required.*path" doc/tools/text-to-image.md
+# Expected: Clear statement about PATH requirement for AI agents
+
+# TC-DOC-002: Check for system-level explanation
+grep -n -i "system-level\|system wide\|shared.*project" doc/tools/text-to-image.md
+# Expected: Explanation of system-level tool nature
+```
+
+## 8. Risks, Assumptions, and Open Questions
+
+### 8.1 Risks
+
+| Risk ID | Risk | Impact | Probability | Mitigation |
+|---------|------|--------|-------------|-----------|
+| RSK-TP-1 | Manual review misses edge cases in documentation | Medium | Low | Follow structured review checklist from this test plan |
+| RSK-TP-2 | Agent prompt changes break other workflows | Low | Low | Scope is limited to tool invocation; other prompt sections unchanged |
+| RSK-TP-3 | User confusion during transition period | Medium | Medium | Documentation clarifies migration; PATH works for both approaches |
+
+### 8.2 Assumptions
+
+- The `text-to-image` CLI tool is correctly implemented as a system PATH command (current design)
+- Users read documentation when directed by error messages
+- The agent's bash tool correctly reports command-not-found errors
+- Reviewers have access to the repository files for manual verification
+
+### 8.3 Open Questions
+
+| Question ID | Question | Blocking | Owner | Resolution |
+|-------------|----------|----------|-------|------------|
+| OQ-TP-1 | Should there be a smoke test with actual agent invocation? | No | N/A | Out of scope — requires API keys and setup overhead; manual review suffices for prompt changes |
+
+## 9. Plan Revision Log
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-03-27 | @cwiakalski | Initial test plan created |
+
+## 10. Test Execution Log
+
+| TC ID | Run Date | Result | Notes |
+|-------|----------|--------|-------|
+| - | - | - | Test plan not yet executed |

--- a/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/code-review/findings-iter-1.json
+++ b/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/code-review/findings-iter-1.json
@@ -1,0 +1,184 @@
+{
+  "iteration": 1,
+  "date": "2026-03-27",
+  "reviewer": "reviewer",
+  "branch": "fix/GH-47/fix-image-generator-tool-path",
+  "base": "main",
+  "status": "PASS",
+  "findings": [],
+  "plan_compliance": {
+    "tasks_checked": [
+      {
+        "task": "1.1",
+        "description": "Restructure Installation section to emphasize system-level tool requirement",
+        "status": "PASSED",
+        "evidence": "Installation section in doc/tools/text-to-image.md now has subsections 'For Human Users' and 'For AI Agent Integration' with comparison table"
+      },
+      {
+        "task": "1.2",
+        "description": "Remove 'optionally' from PATH instructions",
+        "status": "PASSED",
+        "evidence": "PATH installation now explicitly marked as 'required for AI agents, recommended for all users' with IMPORTANT callout"
+      },
+      {
+        "task": "1.3",
+        "description": "Add clarification box explaining system tool vs. per-project dependency",
+        "status": "PASSED",
+        "evidence": "Comparison table added at lines 131-138 explaining System Tool vs Per-Project Dependency"
+      },
+      {
+        "task": "1.4",
+        "description": "Add explicit note: PATH installation required for AI agent usage",
+        "status": "PASSED",
+        "evidence": "IMPORTANT blockquote at lines 125-127 explicitly states PATH installation is required for AI agent usage"
+      },
+      {
+        "task": "2.1",
+        "description": "Update <tool_reference> section with system PATH invocation and installation links",
+        "status": "PASSED",
+        "evidence": "Line 46: 'CLI: text-to-image (system PATH command)', lines 48-49: Installation and Provider Setup links"
+      },
+      {
+        "task": "2.2",
+        "description": "Update <process> Step 1 with tool availability detection and error handling",
+        "status": "PASSED",
+        "evidence": "Lines 210-234: Complete error handling for 'command not found' (exit 127) and 'empty providers' scenarios with documentation links"
+      },
+      {
+        "task": "2.3",
+        "description": "Update all example commands to use text-to-image (remove tools/ prefix)",
+        "status": "PASSED",
+        "evidence": "All 4 examples (lines 325, 340, 354, 368) use 'text-to-image' without 'tools/' prefix. Grep confirms only doc path refs remain"
+      },
+      {
+        "task": "2.4",
+        "description": "Preserve all existing model selection, prompt engineering, and sidecar guidance unchanged",
+        "status": "PASSED",
+        "evidence": "Model routing table, use_case_classification, prompt_engineering, and sidecar_yaml sections unchanged"
+      },
+      {
+        "task": "3.1",
+        "description": "Review both modified files for consistency and accuracy",
+        "status": "PASSED",
+        "evidence": "Both files aligned: agent links to doc anchors, doc provides anchored sections"
+      },
+      {
+        "task": "3.2",
+        "description": "Verify no remaining tools/text-to-image references in agent prompt",
+        "status": "PASSED",
+        "evidence": "Grep shows only 'doc/tools/text-to-image.md' path refs remain (4 occurrences, all correct doc links)"
+      },
+      {
+        "task": "3.3",
+        "description": "Verify documentation links are correct and resolvable",
+        "status": "PASSED",
+        "evidence": "Anchors verified: #installation anchor at line 87, #provider-setup anchor at line 141"
+      }
+    ],
+    "all_tasks_done": true,
+    "plan_gaps": {
+      "open_tasks": [],
+      "done_but_unchecked": [],
+      "checked_but_missing": []
+    }
+  },
+  "spec_compliance": {
+    "acceptance_criteria": [
+      {
+        "id": "AC-F1-1",
+        "criterion": "All tool invocations use text-to-image (not tools/text-to-image)",
+        "status": "PASSED",
+        "evidence": "All command invocations in agent prompt use bare 'text-to-image'; doc refs to 'doc/tools/text-to-image.md' are documentation paths, not invocations"
+      },
+      {
+        "id": "AC-F3-1",
+        "criterion": "Agent reports 'tool not installed' with installation URL, does NOT search project directories",
+        "status": "PASSED",
+        "evidence": "Lines 214-224 in agent: explicit 'command not found' handling with installation URL and explicit instruction 'Do NOT search project directories'"
+      },
+      {
+        "id": "AC-F4-1",
+        "criterion": "Agent reports 'no providers configured' with link to Provider Setup section",
+        "status": "PASSED",
+        "evidence": "Lines 226-232 in agent: explicit empty providers handling with link to '#provider-setup'"
+      },
+      {
+        "id": "AC-F5-1",
+        "criterion": "Documentation states PATH installation is required for AI agent usage",
+        "status": "PASSED",
+        "evidence": "Lines 125-127 in doc: IMPORTANT callout explicitly states 'PATH installation is required for AI agent usage'"
+      },
+      {
+        "id": "AC-F5-2",
+        "criterion": "Documentation explains system-level tool shared across projects",
+        "status": "PASSED",
+        "evidence": "Lines 129-138 in doc: comparison table explains System Tool vs Per-Project Dependency pattern"
+      }
+    ],
+    "all_criteria_met": true
+  },
+  "code_quality": {
+    "prompt_quality": {
+      "status": "PASS",
+      "notes": [
+        "XML structure used correctly for Claude/Grok models",
+        "Description frontmatter is concise (line 6: 'Generate AI images via text-to-image CLI')",
+        "Constraints are explicit and complete in <constraints> section",
+        "Inputs/outputs clearly defined",
+        "No verbose prose - structured tags preferred",
+        "Agent respects single responsibility (generation only)",
+        "Delegation boundaries clear (@image-reviewer for quality verification)"
+      ]
+    },
+    "naming_conventions": {
+      "status": "PASS",
+      "notes": [
+        "File name uses kebab-case: image-generator.md",
+        "Agent name matches filename",
+        "Branch naming follows convention: fix/GH-47/<slug>"
+      ]
+    },
+    "documentation": {
+      "status": "PASS",
+      "notes": [
+        "doc/spec/features/ updated via doc-syncer (feature-text-to-image-tool.md)",
+        "CHANGE_FOLDER convention followed correctly",
+        "License headers present on all modified Markdown files"
+      ]
+    },
+    "security": {
+      "status": "PASS",
+      "notes": [
+        "No hardcoded secrets",
+        "No sensitive data in tmp/ paths",
+        "Error messages guide users to install/configure without exposing internals"
+      ]
+    },
+    "error_handling": {
+      "status": "PASS",
+      "notes": [
+        "Exit code 127 handling for 'command not found' is correct",
+        "Empty providers detection is distinct from tool-not-installed",
+        "Clear error messages with actionable guidance and documentation links"
+      ]
+    }
+  },
+  "doc_sync_verification": {
+    "file": "doc/spec/features/feature-text-to-image-tool.md",
+    "changes": {
+      "line_11": "last_updated updated to 2026-03-27",
+      "line_13": "related_changes updated to include GH-47",
+      "lines_150-159": "Integration with Agents section updated to describe PATH invocation and error handling"
+    },
+    "status": "PASS",
+    "notes": "System spec correctly reflects the agent integration changes"
+  },
+  "summary": {
+    "total_findings": 0,
+    "critical": 0,
+    "major": 0,
+    "minor": 0,
+    "nit": 0,
+    "recommendation": "PASS - No remediation required. All acceptance criteria met, all plan tasks completed correctly, code quality heuristics satisfied."
+  }
+}

--- a/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/code-review/review-iter-1.md
+++ b/doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/code-review/review-iter-1.md
@@ -1,0 +1,102 @@
+# Code Review Summary — GH-47 (Iteration 1)
+
+**Date**: 2026-03-27
+**Branch**: fix/GH-47/fix-image-generator-tool-path
+**Base**: main
+**Reviewer**: reviewer
+
+---
+
+## Status: PASS
+
+**Findings**: 0 issues (0 critical · 0 major · 0 minor · 0 nit)
+
+**Remediation Phase**: NONE REQUIRED
+
+---
+
+## Spec Compliance
+
+All acceptance criteria verified:
+
+| AC ID | Criterion | Status |
+|-------|-----------|--------|
+| AC-F1-1 | All tool invocations use `text-to-image` (not `tools/text-to-image`) | PASSED |
+| AC-F3-1 | Agent reports "tool not installed" with installation URL, does NOT search project directories | PASSED |
+| AC-F4-1 | Agent reports "no providers configured" with link to Provider Setup section | PASSED |
+| AC-F5-1 | Documentation states PATH installation is required for AI agent usage | PASSED |
+| AC-F5-2 | Documentation explains system-level tool shared across projects | PASSED |
+
+---
+
+## Plan Task Audit
+
+All 11 tasks across 3 phases completed and verified:
+
+### Phase 1: Documentation (PASSED)
+- Restructured Installation section with "For Human Users" / "For AI Agent Integration" subsections
+- Added comparison table explaining System Tool vs Per-Project Dependency
+- Added IMPORTANT callout: "PATH installation is required for AI agent usage"
+
+### Phase 2: Agent Prompt (PASSED)
+- Updated `<tool_reference>` section: `CLI: text-to-image (system PATH command)`
+- Added Installation and Provider Setup links in tool reference
+- Updated `<process>` Step 1 with complete error handling for:
+  - Exit code 127 (command not found) → "tool not installed" with installation guide
+  - Empty providers list → "no providers configured" with setup guide
+- Updated all 4 example commands to use `text-to-image` without `tools/` prefix
+- Preserved all existing model selection, prompt engineering, and sidecar guidance unchanged
+
+### Phase 3: Finalization (PASSED)
+- No remaining `tools/text-to-image` command references (only `doc/tools/text-to-image.md` doc paths)
+- Documentation anchors verified: `#installation` at line 87, `#provider-setup` at line 141
+- All acceptance criteria from spec are met
+
+---
+
+## Code Quality Heuristics
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| Prompt Quality | PASS | XML structure, clear constraints, single responsibility, proper delegation |
+| Naming Conventions | PASS | kebab-case files, agent name matches filename, branch naming correct |
+| Documentation | PASS | System spec updated via doc-syncer, license headers present |
+| Security | PASS | No hardcoded secrets, actionable error messages without exposing internals |
+| Error Handling | PASS | Distinct error scenarios with clear guidance and documentation links |
+
+---
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `.opencode/agent/image-generator.md` | Updated tool invocation to system PATH, added error handling for tool availability detection |
+| `doc/tools/text-to-image.md` | Restructured Installation section, added AI agent requirements and comparison table |
+| `doc/spec/features/feature-text-to-image-tool.md` | Updated via doc-syncer: Integration section reflects PATH invocation |
+
+---
+
+## Verification Notes
+
+1. **Command invocation grep result**: Only `doc/tools/text-to-image.md` path references remain (4 occurrences) — these are documentation links, not invocation commands.
+
+2. **Error handling patterns**:
+   - Lines 214-224: Clear "command not found" handling with installation URL
+   - Lines 226-232: Clear "empty providers" handling with provider setup link
+   - Lines 224, 232: Explicit instruction NOT to search project directories or delegate to subagents
+
+3. **Documentation anchor verification**:
+   - `#installation` anchor: Line 87 (Installation heading)
+   - `#provider-setup` anchor: Line 141 (Provider Setup heading)
+
+4. **System spec sync**:
+   - `doc/spec/features/feature-text-to-image-tool.md` updated with:
+     - `last_updated: 2026-03-27`
+     - `related_changes: ["GH-26", "GH-47"]`
+     - New "Integration with Agents" section describing PATH invocation and error handling
+
+---
+
+## Next Step
+
+**PROCEED** — No findings, no remediation required. Ready for quality gates (`/check`) and PR creation (`/pr`).

--- a/doc/quality/test-specs/test-spec-text-to-image-tool.md
+++ b/doc/quality/test-specs/test-spec-text-to-image-tool.md
@@ -6,11 +6,11 @@ source: https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/
 id: TEST-SPEC-TEXT-TO-IMAGE-TOOL
 status: Current
 created: 2026-03-07
-last_updated: 2026-03-07
+last_updated: 2026-03-27
 owners: [Juliusz Ćwiąkalski]
 service: tools
 links:
-  related_changes: ["GH-26"]
+  related_changes: ["GH-26", "GH-47"]
   feature_spec: "doc/spec/features/feature-text-to-image-tool.md"
 summary: "Test specification for the text-to-image CLI tool — 81 automated tests across unit, integration, and performance suites."
 ---

--- a/doc/spec/features/feature-text-to-image-tool.md
+++ b/doc/spec/features/feature-text-to-image-tool.md
@@ -6,11 +6,11 @@ source: https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/
 id: SPEC-TEXT-TO-IMAGE-TOOL
 status: Current
 created: 2026-03-07
-last_updated: 2026-03-07
+last_updated: 2026-03-27
 owners: [Juliusz Ćwiąkalski]
 service: tools
 links:
-  related_changes: ["GH-26"]
+  related_changes: ["GH-26", "GH-47"]
   guides:
     - "doc/tools/text-to-image.md"
     - "doc/guides/tools-convention.md"
@@ -147,12 +147,16 @@ Created automatically on first run with permissions `700`. Location overridable 
 
 ## Integration with Agents
 
-The `@image-generator` agent uses the tool for image generation. The agent workflow is:
+The `@image-generator` agent invokes `text-to-image` as a **system PATH command** (not a project-relative path). The agent workflow is:
 
-1. Run `tools/text-to-image --list-models --output-format json` to discover available providers and models
+1. Run `text-to-image --list-models --output-format json` to discover available providers and models
+   - If the command fails with "command not found" (exit code 127), the agent reports that the tool must be installed and added to PATH, with a link to `doc/tools/text-to-image.md#installation`
+   - If the command succeeds but returns an empty providers list, the agent reports that no providers are configured, with a link to `doc/tools/text-to-image.md#provider-setup`
 2. Select an appropriate model based on task type and available providers
 3. Invoke the tool with the selected provider/model and `--output-format json`
 4. Parse JSON response for status and output path
+
+**Prerequisite**: The tool must be installed system-wide and added to PATH. Project-relative invocation is not supported. See `doc/tools/text-to-image.md#installation` for setup instructions.
 
 ## Related Documentation
 

--- a/doc/spec/features/feature-text-to-image-tool.md
+++ b/doc/spec/features/feature-text-to-image-tool.md
@@ -150,13 +150,13 @@ Created automatically on first run with permissions `700`. Location overridable 
 The `@image-generator` agent invokes `text-to-image` as a **system PATH command** (not a project-relative path). The agent workflow is:
 
 1. Run `text-to-image --list-models --output-format json` to discover available providers and models
-   - If the command fails with "command not found" (exit code 127), the agent reports that the tool must be installed and added to PATH, with a link to `doc/tools/text-to-image.md#installation`
-   - If the command succeeds but returns an empty providers list, the agent reports that no providers are configured, with a link to `doc/tools/text-to-image.md#provider-setup`
+   - If the command fails with "command not found" (exit code 127), the agent reports that the tool must be installed and added to PATH, with a link to https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/tools/text-to-image.md#installation
+   - If the command succeeds but returns an empty providers list, the agent reports that no providers are configured, with a link to https://github.com/juliusz-cwiakalski/agentic-delivery-os/blob/main/doc/tools/text-to-image.md#provider-setup
 2. Select an appropriate model based on task type and available providers
 3. Invoke the tool with the selected provider/model and `--output-format json`
 4. Parse JSON response for status and output path
 
-**Prerequisite**: The tool must be installed system-wide and added to PATH. Project-relative invocation is not supported. See `doc/tools/text-to-image.md#installation` for setup instructions.
+**Prerequisite**: For the `@image-generator` agent, the tool must be installed system-wide and added to PATH; the agent does not support project-relative invocation. See `doc/tools/text-to-image.md#installation` for setup instructions.
 
 ## Related Documentation
 

--- a/doc/tools/text-to-image.md
+++ b/doc/tools/text-to-image.md
@@ -90,16 +90,17 @@ The tool is designed to be invoked by humans, shell scripts, CI/CD pipelines, an
 
 ### For Human Users (CLI usage)
 
-1. Clone the repository (or copy the tool file):
+1. Clone the repository:
 
 ```bash
 git clone https://github.com/juliusz-cwiakalski/agentic-delivery-os.git
+cd agentic-delivery-os
 ```
 
-2. The tool is already executable. Verify:
+2. Verify the tool is executable:
 
 ```bash
-tools/text-to-image --version
+./tools/text-to-image --version
 ```
 
 3. **Install to PATH (required for AI agents, recommended for all users):**

--- a/doc/tools/text-to-image.md
+++ b/doc/tools/text-to-image.md
@@ -86,6 +86,10 @@ The tool is designed to be invoked by humans, shell scripts, CI/CD pipelines, an
 
 ## Installation
 
+`text-to-image` is a **system-level CLI tool** designed to be installed once and shared across multiple projects. It is not a per-project dependency.
+
+### For Human Users (CLI usage)
+
 1. Clone the repository (or copy the tool file):
 
 ```bash
@@ -98,14 +102,41 @@ git clone https://github.com/juliusz-cwiakalski/agentic-delivery-os.git
 tools/text-to-image --version
 ```
 
-3. Optionally, add `tools/` to your PATH for convenience:
+3. **Install to PATH (required for AI agents, recommended for all users):**
 
 ```bash
+# Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
 export PATH="$PATH:/path/to/agentic-delivery-os/tools"
+
+# Then reload your shell or source the profile
+source ~/.bashrc  # or ~/.zshrc
+```
+
+4. Verify PATH installation:
+
+```bash
 text-to-image --version
 ```
 
-4. On first run, the tool creates `~/.ai/text-to-image/` (permissions `700`) for configuration, cache, and logs.
+5. On first run, the tool creates `~/.ai/text-to-image/` (permissions `700`) for configuration, cache, and logs.
+
+### For AI Agent Integration
+
+> **IMPORTANT: PATH installation is required for AI agent usage.**
+>
+> AI agents like `@image-generator` invoke `text-to-image` as a system command, not a project-relative path. You must add the `tools/` directory to your PATH for AI agents to discover and use this tool.
+
+### System Tool vs. Per-Project Dependency
+
+| Aspect | System Tool (this tool) | Per-Project Dependency |
+|--------|------------------------|------------------------|
+| Installation location | One central location (e.g., `~/tools/`) | Inside project's `node_modules/` or `vendor/` |
+| Version management | Manual (single version) | Per-project lockfile |
+| Updates | Global update affects all projects | Isolated per project |
+| PATH requirement | **Required** | Usually integrated by package manager |
+| AI agent access | Automatic (PATH lookup) | Requires project-relative path |
+
+This tool follows the **system tool** pattern: install once, use everywhere.
 
 ## Provider Setup
 
@@ -186,7 +217,7 @@ The service account needs the `roles/aiplatform.user` role. Requires `openssl` a
 You can also pass the path via CLI flag:
 
 ```bash
-tools/text-to-image --google-credentials /path/to/service-account.json --provider google --prompt "..." --output img.png
+text-to-image --google-credentials /path/to/service-account.json --provider google --prompt "..." --output img.png
 ```
 
 **Method 2: gcloud CLI (recommended for development)**
@@ -209,7 +240,7 @@ export GOOGLE_PROJECT_ID="your-google-project-id"
 **Override auto-detection:**
 
 ```bash
-tools/text-to-image --google-auth-method gcloud --provider google --prompt "..." --output img.png
+text-to-image --google-auth-method gcloud --provider google --prompt "..." --output img.png
 ```
 
 Valid methods: `auto`, `json`, `service-account`, `gcloud`, `api-key`.
@@ -255,7 +286,7 @@ export HF_API_KEY="hf-your-huggingface-token"
 
 ```bash
 export HF_MODEL="CompVis/stable-diffusion-v1-4"
-tools/text-to-image --provider huggingface --prompt "..." --output img.png
+text-to-image --provider huggingface --prompt "..." --output img.png
 ```
 
 **Gotchas:**
@@ -313,7 +344,7 @@ export REPLICATE_API_TOKEN="your-replicate-token"
 
 ```bash
 export REPLICATE_MODEL="owner/model-name:version"
-tools/text-to-image --provider replicate --prompt "..." --output img.png
+text-to-image --provider replicate --prompt "..." --output img.png
 ```
 
 **Gotchas:**
@@ -352,13 +383,13 @@ export SILICONFLOW_API_KEY="your-siliconflow-key"
 ### Single image generation
 
 ```bash
-tools/text-to-image --prompt "sunset over mountains" --output sunset.png
+text-to-image --prompt "sunset over mountains" --output sunset.png
 ```
 
 ### Specify provider and model
 
 ```bash
-tools/text-to-image --prompt "portrait" --provider openai --model dall-e-3 --output portrait.png
+text-to-image --prompt "portrait" --provider openai --model dall-e-3 --output portrait.png
 ```
 
 ### Quality profiles
@@ -367,13 +398,13 @@ Quality profiles automatically select the best available provider based on your 
 
 ```bash
 # High quality (default): OpenAI -> Stability -> Google
-tools/text-to-image --prompt "product photo" --quality high --output product.png
+text-to-image --prompt "product photo" --quality high --output product.png
 
 # Medium quality: Stability -> OpenAI -> Replicate
-tools/text-to-image --prompt "illustration" --quality medium --output illustration.png
+text-to-image --prompt "illustration" --quality medium --output illustration.png
 
 # Low quality (fastest, cheapest): Hugging Face -> Stability -> SiliconFlow
-tools/text-to-image --prompt "quick sketch" --quality low --output sketch.png
+text-to-image --prompt "quick sketch" --quality low --output sketch.png
 ```
 
 > **Important: Quality profiles vs. direct model selection**
@@ -384,10 +415,10 @@ tools/text-to-image --prompt "quick sketch" --quality low --output sketch.png
 >
 > ```bash
 > # Recommended: explicit model selection based on quality data
-> tools/text-to-image --prompt "product photo" --provider google --model imagen-4.0-ultra-generate-001 --output product.avif
+> text-to-image --prompt "product photo" --provider google --model imagen-4.0-ultra-generate-001 --output product.avif
 >
 > # Best value: Imagen 4.0 Fast at ~$0.020/img scores 79.4% avg
-> tools/text-to-image --prompt "illustration" --provider google --model imagen-4.0-fast-generate-001 --output illustration.avif
+> text-to-image --prompt "illustration" --provider google --model imagen-4.0-fast-generate-001 --output illustration.avif
 > ```
 >
 > **Recommended models by use case (from E2E evaluation):**
@@ -410,7 +441,7 @@ tools/text-to-image --prompt "quick sketch" --quality low --output sketch.png
 ### Custom dimensions
 
 ```bash
-tools/text-to-image --prompt "panoramic landscape" --width 2048 --height 1024 --output panorama.png
+text-to-image --prompt "panoramic landscape" --width 2048 --height 1024 --output panorama.png
 ```
 
 ### Output formats
@@ -421,16 +452,16 @@ The output format is determined by the file extension in `--output`:
 
 ```bash
 # PNG (default, lossless)
-tools/text-to-image --prompt "landscape" --output landscape.png
+text-to-image --prompt "landscape" --output landscape.png
 
 # AVIF (recommended — best compression/quality ratio)
-tools/text-to-image --prompt "landscape" --output landscape.avif
+text-to-image --prompt "landscape" --output landscape.avif
 
 # WebP (good compression, wide browser support)
-tools/text-to-image --prompt "landscape" --output landscape.webp
+text-to-image --prompt "landscape" --output landscape.webp
 
 # JPG (lossy, smallest for photos)
-tools/text-to-image --prompt "landscape" --output landscape.jpg
+text-to-image --prompt "landscape" --output landscape.jpg
 ```
 
 If no recognized extension is specified, the tool auto-appends the provider's native format (usually `.png`).
@@ -440,7 +471,7 @@ If no recognized extension is specified, the tool auto-appends the provider's na
 ### Negative prompts
 
 ```bash
-tools/text-to-image --prompt "portrait of a cat" --negative-prompt "blurry, low quality, distorted" --output cat.png
+text-to-image --prompt "portrait of a cat" --negative-prompt "blurry, low quality, distorted" --output cat.png
 ```
 
 ### Multi-model comparison
@@ -448,7 +479,7 @@ tools/text-to-image --prompt "portrait of a cat" --negative-prompt "blurry, low 
 Generate the same prompt across multiple models simultaneously:
 
 ```bash
-tools/text-to-image --prompt "futuristic city" --models "dall-e-3,stable-diffusion-xl-1024-v1-0,flux-1.1-pro" --output city.png
+text-to-image --prompt "futuristic city" --models "dall-e-3,stable-diffusion-xl-1024-v1-0,flux-1.1-pro" --output city.png
 ```
 
 This produces model-suffixed output files: `city-dall-e-3.png`, `city-stable-diffusion-xl-1024-v1-0.png`, `city-flux-1.1-pro.png`.
@@ -481,10 +512,10 @@ Run sequentially or in parallel:
 
 ```bash
 # Sequential
-tools/text-to-image --config batch.yaml
+text-to-image --config batch.yaml
 
 # Parallel (up to 4 concurrent jobs)
-tools/text-to-image --config batch.yaml --parallel --max-parallel 4
+text-to-image --config batch.yaml --parallel --max-parallel 4
 ```
 
 ### Dry run
@@ -492,7 +523,7 @@ tools/text-to-image --config batch.yaml --parallel --max-parallel 4
 Validate command structure and see what API calls would be made:
 
 ```bash
-tools/text-to-image --dry-run --prompt "test image" --output test.png
+text-to-image --dry-run --prompt "test image" --output test.png
 ```
 
 ### Metadata embedding
@@ -500,7 +531,7 @@ tools/text-to-image --dry-run --prompt "test image" --output test.png
 Embed EXIF/XMP metadata in generated images (requires `exiftool`, falls back to `.metadata` JSON sidecar):
 
 ```bash
-tools/text-to-image --prompt "landscape" --output landscape.jpg \
+text-to-image --prompt "landscape" --output landscape.jpg \
   --metadata --artist "AI Generator" --copyright "2026" \
   --keywords "ai,generated,landscape" --description "AI-generated landscape"
 ```
@@ -509,11 +540,11 @@ tools/text-to-image --prompt "landscape" --output landscape.jpg \
 
 ```bash
 # Image generation with JSON result
-tools/text-to-image --prompt "test" --output test.png --output-format json
+text-to-image --prompt "test" --output test.png --output-format json
 # Output: {"status":"success","output":"/path/to/test.png"}
 
 # Model listing with JSON
-tools/text-to-image --list-models --output-format json
+text-to-image --list-models --output-format json
 # Output: [{"provider":"openai","model":"dall-e-3","name":"DALL-E 3",...}, ...]
 ```
 
@@ -521,25 +552,25 @@ tools/text-to-image --list-models --output-format json
 
 ```bash
 # List models for configured providers
-tools/text-to-image --list-models
+text-to-image --list-models
 
 # List all known models (including unconfigured providers)
-tools/text-to-image --all-models
+text-to-image --all-models
 ```
 
 ### Google Imagen with specific auth method
 
 ```bash
 # Force gcloud authentication
-tools/text-to-image --provider google --google-auth-method gcloud \
+text-to-image --provider google --google-auth-method gcloud \
   --prompt "gourmet dish" --output dish.png
 
 # Use service account JSON
-tools/text-to-image --provider google --google-credentials /path/to/sa.json \
+text-to-image --provider google --google-credentials /path/to/sa.json \
   --prompt "product photo" --output product.png
 
 # Specify region
-tools/text-to-image --provider google --google-location europe-west1 \
+text-to-image --provider google --google-location europe-west1 \
   --prompt "cityscape" --output city.png
 ```
 
@@ -721,7 +752,7 @@ ls -la "$(dirname output.png)"
 Enable verbose output for detailed execution logs:
 
 ```bash
-tools/text-to-image --verbose --prompt "test" --output test.png
+text-to-image --verbose --prompt "test" --output test.png
 ```
 
 Verbose mode shows:


### PR DESCRIPTION
## Summary

- Fixed `@image-generator` agent to invoke `text-to-image` as a system PATH command instead of project-relative `tools/text-to-image`
- Added explicit error handling for "tool not installed" and "no providers configured" scenarios
- Clarified documentation that PATH installation is required for AI agent usage

## Problem

The `@image-generator` agent referenced the `text-to-image` CLI as a project-relative path (`tools/text-to-image`), but the tool is designed to be installed system-wide and added to PATH. When the tool was not installed, the agent would:
1. Attempt `tools/text-to-image --list-models` which fails with "no such file or directory"
2. Search project directories for the tool (confusing and unhelpful)
3. Delegate to a subagent producing confusing "SYSTEM_LIMITATION" messages
4. Never guide users to install the tool

## Solution

1. **Agent prompt** (`.opencode/agent/image-generator.md`):
   - Changed all `tools/text-to-image` invocations to `text-to-image` (system PATH command)
   - Added explicit detection for exit code 127 ("command not found")
   - Added clear error messages with installation URL when tool is missing
   - Added separate handling for "no providers configured" scenario

2. **Documentation** (`doc/tools/text-to-image.md`):
   - Restructured Installation section to clarify this is a system-level tool
   - Added "For AI Agent Integration" callout explaining PATH requirement
   - Added comparison table: System Tool vs. Per-Project Dependency

3. **System spec** (`doc/spec/features/feature-text-to-image-tool.md`):
   - Updated "Integration with Agents" section to reflect system PATH invocation
   - Added error handling documentation

## Files Changed

- `.opencode/agent/image-generator.md`
- `doc/tools/text-to-image.md`
- `doc/spec/features/feature-text-to-image-tool.md`
- Change artifacts in `doc/changes/2026-03/2026-03-27--GH-47--fix-image-generator-tool-path/`

## Test Plan

- Verified all `tools/text-to-image` patterns replaced with `text-to-image`
- Verified agent prompt includes tool availability detection step
- Verified agent prompt includes "tool not installed" error handling with installation URL
- Verified agent prompt includes "no providers configured" error handling with provider setup link
- Verified documentation states PATH requirement for AI agent usage

Fixes #47