### PR TITLE
fix(GH-126): stop retrying when PM exits normally but GitHub API unavailable

### DIFF
--- a/scripts/.tests/test-deliver-ticket.sh
+++ b/scripts/.tests/test-deliver-ticket.sh
@@ -334,12 +334,40 @@ test_classify_unknown() {
   assert_eq "unknown" "${result}" "Should classify as unknown on gh failure"
 }
 
-# TC-DT-06d: unknown classification → continue (no restart burn)
+# TC-DT-06d: stuck + unknown classification → continue (no restart burn)
+# m-7: "unknown" (gh/network failure) doesn't burn a restart slot — but only
+# when the session was killed for staleness (stuck). A finished session that
+# can't be classified should STOP instead (see TC-DT-06e).
 test_unknown_continues() {
   local result
-  result="$(decide_after_iteration "finished" "unknown" 1 10)"
+  result="$(decide_after_iteration "stuck" "unknown" 1 10)"
 
-  assert_eq "continue" "${result}" "Should continue (not burn restart) on unknown"
+  assert_eq "continue" "${result}" "Should continue (not burn restart) on stuck+unknown"
+}
+
+# TC-DT-06e: decide_after_iteration: finished + unknown → stop:0:finished
+# GH-126: When the PM session finished normally (opencode exited on its own)
+# but post-session GitHub classification is unknown (rate limit / network), the
+# delivery should STOP — the PM completed its work; retrying won't change the
+# outcome. Previously this returned "continue", causing an infinite retry loop.
+test_decide_finished_unknown_stops() {
+  local result
+  result="$(decide_after_iteration "finished" "unknown" 1 10)"
+  assert_eq "stop:0:finished" "${result}" "finished+unknown should stop with exit 0"
+}
+
+# TC-DT-06f: decide_after_iteration: stuck + unknown → continue (still retries)
+test_decide_stuck_unknown_continues() {
+  local result
+  result="$(decide_after_iteration "stuck" "unknown" 1 10)"
+  assert_eq "continue" "${result}" "stuck+unknown should continue"
+}
+
+# TC-DT-06g: decide_after_iteration: finished + failed → continue (retries up to max)
+test_decide_finished_failed_continues() {
+  local result
+  result="$(decide_after_iteration "finished" "failed" 1 10)"
+  assert_eq "continue" "${result}" "finished+failed should continue"
 }
 
 # ============================================================================
@@ -650,7 +678,10 @@ main() {
   run_test "TC-DT-07c: classify pr-open" test_classify_pr_open
   run_test "TC-DT-07d: classify failed" test_classify_failed
   run_test "TC-DT-07e: classify unknown (gh failure)" test_classify_unknown
-  run_test "TC-DT-06d: unknown classification continues without restart burn" test_unknown_continues
+  run_test "TC-DT-06d: stuck+unknown continues without restart burn" test_unknown_continues
+  run_test "TC-DT-06e: finished+unknown stops (GH-126 retry-loop fix)" test_decide_finished_unknown_stops
+  run_test "TC-DT-06f: stuck+unknown continues" test_decide_stuck_unknown_continues
+  run_test "TC-DT-06g: finished+failed continues" test_decide_finished_failed_continues
   run_test "TC-DT-08: prompt contains ticket and branch" test_prompt_contains_ticket
   run_test "TC-DT-08b: prompt has PR check instructions" test_prompt_has_pr_check
   run_test "TC-DT-08c: prompt has blocked workflow" test_prompt_has_blocked_workflow

--- a/scripts/build-claude-plugin.sh
+++ b/scripts/build-claude-plugin.sh
@@ -63,6 +63,33 @@ readonly REPO_ROOT
 # Tool configuration (extensible pattern)
 readonly TOOL="${TOOL:-claude}"
 
+# Verbosity flags (needed by log() below)
+VERBOSE="${VERBOSE:-false}"
+DRY_RUN="${DRY_RUN:-false}"
+
+# ==============================================================================
+# Utility Functions (defined before first use — shellcheck SC2218)
+# ==============================================================================
+
+log() {
+    if [[ "${VERBOSE}" == "true" ]]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+    fi
+}
+
+error() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+warn() {
+    echo "WARN: $*" >&2
+}
+
+# ==============================================================================
+# Validation
+# ==============================================================================
+
 # Safety: TOOL flows into OUTPUT_DIR and is later rm -rf'd. Validate it is a
 # simple identifier (letters, digits, hyphen, underscore) to prevent path
 # traversal via values like "../../evil".
@@ -91,29 +118,6 @@ EOF
 
 # Default model for files without claude.model
 readonly DEFAULT_MODEL="sonnet"
-
-# Verbosity flags
-VERBOSE="${VERBOSE:-false}"
-DRY_RUN="${DRY_RUN:-false}"
-
-# ==============================================================================
-# Utility Functions
-# ==============================================================================
-
-log() {
-    if [[ "${VERBOSE}" == "true" ]]; then
-        echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
-    fi
-}
-
-error() {
-    echo "ERROR: $*" >&2
-    exit 1
-}
-
-warn() {
-    echo "WARN: $*" >&2
-}
 
 # ==============================================================================
 # YAML Frontmatter Parsing

--- a/scripts/deliver-ticket.sh
+++ b/scripts/deliver-ticket.sh
@@ -496,6 +496,14 @@ classify_result() {
 decide_after_iteration() {
   local -r monitor_result="$1" classification="$2" iteration="$3" max_restarts="$4"
 
+  # When the PM session finished normally (opencode exited on its own), accept
+  # it as completion. A GitHub API failure during post-session classification is
+  # a monitoring gap, not a delivery failure — retrying won't change the outcome.
+  if [[ "${monitor_result}" == "finished" && "${classification}" == "unknown" ]]; then
+    printf 'stop:0:finished'
+    return 0
+  fi
+
   if [[ "${monitor_result}" == "stuck" ]]; then
     if (( iteration >= max_restarts )); then
       printf 'stop:1:max-restarts'
@@ -676,7 +684,7 @@ deliver_loop() {
       # m-7: "unknown" (gh/network failure) doesn't burn a restart slot —
       # decrement the iteration counter so MAX_RESTARTS isn't consumed by
       # transient outages, and retry after a longer sleep.
-      if [[ "${classification}" == "unknown" ]]; then
+      if [[ "${classification}" == "unknown" && "${monitor_result}" == "stuck" ]]; then
         ((iteration--)) || true
         log_warn "Transient failure for ${ticket_ref} (${monitor_result}/${classification}) — retrying after extended sleep"
         sleep "$((LOOP_SLEEP_SECONDS * 6))"
@@ -698,6 +706,7 @@ deliver_loop() {
       merged)   log_done "${ticket_ref} — merged/closed" ;;
       blocked)  log_done "${ticket_ref} — blocked (human-input-needed)" ;;
       pr-open)  log_done "${ticket_ref} — PR open" ;;
+      finished) log_done "${ticket_ref} — PM completed (state unverified — GitHub API unavailable)" ;;
       max-restarts) log_failed "${ticket_ref} — max restarts exceeded" ;;
       *)        log_warn "${ticket_ref} — ${message}" ;;
     esac


### PR DESCRIPTION
Closes #126.

## Problem

`deliver-ticket.sh` entered an infinite retry loop (~30 iterations in 67 minutes) when:
1. PM session (`opencode run`) exited normally (exit 0 — PR already open, awaiting review)
2. Post-session `classify_result()` call to `gh issue view` failed (GitHub API rate-limited)
3. `classify_result()` returned `"unknown"`
4. `decide_after_iteration("finished", "unknown", ...)` returned `"continue"`
5. Loop body did `iteration--` making retries unbounded

Observed in production: GH-108 (PR #122 open, awaiting review) retried ~30 times, each iteration ~30s, burning more API calls.

## Fix

**`decide_after_iteration()`:** When `monitor_result == "finished"` and `classification == "unknown"`, return `stop:0:finished`. The PM session completed its lifecycle — a GitHub API failure during post-session verification is a monitoring gap, not a delivery failure. Retrying won't change the outcome.

**Loop body:** The `iteration--` no-burn-restart behavior is now scoped to `stuck + unknown` only (finished+unknown stops, never reaches this path).

**Message handling:** New `finished)` case: `"PM completed (state unverified — GitHub API unavailable)"`.

## Behavior matrix

| monitor_result | classification | Before | After |
|---|---|---|---|
| finished | merged/blocked/pr-open | stop:0 | stop:0 (unchanged) |
| finished | unknown | **continue (BUG)** | **stop:0:finished (FIXED)** |
| finished | failed | continue (retry) | continue (unchanged) |
| stuck | unknown | continue (retry) | continue (unchanged) |
| stuck | * | continue or max-restarts | continue or max-restarts (unchanged) |

## Tests

- `test-deliver-ticket.sh`: 38/38 (3 new tests: TC-DT-06e finished+unknown→stop, TC-DT-06f stuck+unknown→continue, TC-DT-06g finished+failed→continue)
- `test-batch-deliver.sh`: 15/15 (no changes needed — batch already treats exit 0 as done)

Refs: GH-126