### PR TITLE
fix(GH-129): stabilize batch delivery — gh format, labelNames, log stdout

### DIFF
--- a/scripts/.tests/test-batch-deliver.sh
+++ b/scripts/.tests/test-batch-deliver.sh
@@ -161,6 +161,13 @@ EOF
   assert_eq "feat/another" "${PARSED_BRANCHES[2]}"
 }
 
+# TC-BD-03c: to_issue_number converts workItemRef to bare number for gh CLI
+test_to_issue_number() {
+  assert_eq "37" "$(to_issue_number "GH-37")" "GH-37 → 37"
+  assert_eq "123" "$(to_issue_number "PDEV-123")" "PDEV-123 → 123"
+  assert_eq "37" "$(to_issue_number "37")" "bare number stays"
+}
+
 # ============================================================================
 # TESTS: Pre-flight Skip (TC-BD-04 through TC-BD-06)
 # ============================================================================
@@ -170,7 +177,7 @@ test_skip_merged() {
   _gh() {
     case "$1" in
       issue)
-        printf '%s' '{"state":"OPEN","labelNames":[]}'
+        printf '%s' '{"state":"OPEN","labels":[]}'
         ;;
       pr)
         printf '%s' '[{"mergedAt":"2025-01-15T10:30:00Z"}]'
@@ -189,7 +196,7 @@ test_skip_blocked() {
   _gh() {
     case "$1" in
       issue)
-        printf '%s' '{"state":"OPEN","labelNames":["human-input-needed"]}'
+        printf '%s' '{"state":"OPEN","labels":[{"name":"human-input-needed"}]}'
         ;;
       pr)
         printf '%s' '[]'
@@ -206,7 +213,7 @@ test_skip_blocked() {
 # TC-BD-06: skip-closed — mock gh to return CLOSED state → SKIP
 test_skip_closed() {
   _gh() {
-    printf '%s' '{"state":"CLOSED","labelNames":[]}'
+    printf '%s' '{"state":"CLOSED","labels":[]}'
   }
 
   local skip_reason
@@ -220,7 +227,7 @@ test_no_skip_active() {
   _gh() {
     case "$1" in
       issue)
-        printf '%s' '{"state":"OPEN","labelNames":[]}'
+        printf '%s' '{"state":"OPEN","labels":[]}'
         ;;
       pr)
         printf '%s' '[]'
@@ -295,6 +302,7 @@ main() {
   run_test "TC-BD-02: parse colon syntax" test_parse_colon_syntax
   run_test "TC-BD-03: parse mixed positional + colon" test_parse_mixed
   run_test "TC-BD-03b: load from file" test_parse_from_file
+  run_test "TC-BD-03c: to_issue_number strips prefix" test_to_issue_number
   run_test "TC-BD-04: skip merged" test_skip_merged
   run_test "TC-BD-05: skip blocked" test_skip_blocked
   run_test "TC-BD-06: skip closed" test_skip_closed

--- a/scripts/.tests/test-deliver-ticket.sh
+++ b/scripts/.tests/test-deliver-ticket.sh
@@ -139,6 +139,13 @@ test_parse_pdev_ticket() {
   assert_eq "fix/bug" "${branch}"
 }
 
+# TC-DT-02c: to_issue_number converts workItemRef to bare number for gh CLI
+test_to_issue_number() {
+  assert_eq "37" "$(to_issue_number "GH-37")" "GH-37 → 37"
+  assert_eq "123" "$(to_issue_number "PDEV-123")" "PDEV-123 → 123"
+  assert_eq "37" "$(to_issue_number "37")" "bare number stays"
+}
+
 # ============================================================================
 # TESTS: Branch Resolution
 # ============================================================================
@@ -262,7 +269,7 @@ test_stuck_at_max_restarts() {
 # TC-DT-07: exit classification — human-input-needed → blocked
 test_classify_blocked() {
   _gh() {
-    printf '%s' '{"state":"OPEN","labelNames":["human-input-needed"]}'
+    printf '%s' '{"state":"OPEN","labels":[{"name":"human-input-needed"}]}'
   }
 
   local result
@@ -274,7 +281,7 @@ test_classify_blocked() {
 # TC-DT-07b: closed issue → merged
 test_classify_merged_closed() {
   _gh() {
-    printf '%s' '{"state":"CLOSED","labelNames":[]}'
+    printf '%s' '{"state":"CLOSED","labels":[]}'
   }
 
   local result
@@ -288,7 +295,7 @@ test_classify_pr_open() {
   _gh() {
     case "$1" in
       issue)
-        printf '%s' '{"state":"OPEN","labelNames":[]}'
+        printf '%s' '{"state":"OPEN","labels":[]}'
         ;;
       pr)
         printf '%s' '[{"number":42}]'
@@ -307,7 +314,7 @@ test_classify_failed() {
   _gh() {
     case "$1" in
       issue)
-        printf '%s' '{"state":"OPEN","labelNames":[]}'
+        printf '%s' '{"state":"OPEN","labels":[]}'
         ;;
       pr)
         printf '%s' '[]'
@@ -599,7 +606,7 @@ OPENCODE
   cat >"${bin_dir}/gh" <<GH
 #!/usr/bin/env bash
 case "\$1" in
-  issue) printf '%s' '{"state":"OPEN","labelNames":[]}' ;;
+  issue) printf '%s' '{"state":"OPEN","labels":[]}' ;;
   pr)
     if printf '%s ' "\$@" | grep -q -- '--state open'; then
       printf '%s' '[]'
@@ -664,6 +671,7 @@ main() {
   run_test "TC-DT-01c: reject invalid ticket ref" test_validate_ticket_ref_invalid
   run_test "TC-DT-02: parse ticket:branch" test_parse_ticket_with_branch
   run_test "TC-DT-02b: parse PDEV ticket:branch" test_parse_pdev_ticket
+  run_test "TC-DT-02c: to_issue_number strips prefix" test_to_issue_number
   run_test "TC-DT-03: branch mismatch warning" test_branch_mismatch_warning
   run_test "TC-DT-04: branch resolution from mapping" test_branch_from_mapping
   run_test "TC-DT-04b: branch from arg (no mapping)" test_branch_from_arg_no_mapping

--- a/scripts/batch-deliver.sh
+++ b/scripts/batch-deliver.sh
@@ -60,10 +60,10 @@ trap 'log_warn "Interrupted"; exit 130' INT TERM
 # ============================================================================
 _ts() { date '+%H:%M:%S'; }
 
-log_info()   { printf '[%s] ℹ %s %s\n' "$(_ts)" "${LOG_TAG}" "$*"; }
+log_info()   { printf '[%s] ℹ %s %s\n' "$(_ts)" "${LOG_TAG}" "$*" >&2; }
 log_warn()   { printf '[%s] ⚠ %s %s\n' "$(_ts)" "${LOG_TAG}" "$*" >&2; }
 log_err()    { printf '[%s] ✗ %s %s\n' "$(_ts)" "${LOG_TAG}" "$*" >&2; }
-log_debug()  { [[ "${VERBOSE}" == "true" ]] && printf '[%s] ℹ DEBUG %s %s\n' "$(_ts)" "${LOG_TAG}" "$*" || true; }
+log_debug()  { [[ "${VERBOSE}" == "true" ]] && printf '[%s] ℹ DEBUG %s %s\n' "$(_ts)" "${LOG_TAG}" "$*" >&2 || true; }
 
 die() { log_err "$@"; exit "${EXIT_USAGE}"; }
 
@@ -97,6 +97,12 @@ extract_branch() {
   fi
 }
 
+# PURE: Convert workItemRef (GH-37) to bare issue number (37) for gh CLI
+to_issue_number() {
+  local -r ticket_ref="$1"
+  printf '%s' "${ticket_ref#*-}"
+}
+
 # Add a ticket spec to the parsed arrays
 add_ticket() {
   local -r spec="$1"
@@ -128,7 +134,7 @@ should_skip_ticket() {
   local -r ticket_ref="$1"
 
   local issue_json
-  issue_json="$(_gh issue view "${ticket_ref}" --json state,labelNames 2>/dev/null)" || {
+  issue_json="$(_gh issue view "$(to_issue_number "${ticket_ref}")" --json state,labels 2>/dev/null)" || {
     return 1  # Can't determine state → don't skip
   }
 
@@ -142,7 +148,7 @@ should_skip_ticket() {
   fi
 
   # human-input-needed → skip
-  if printf '%s' "${issue_json}" | _jq -r '.labelNames[]?' 2>/dev/null | grep -q 'human-input-needed'; then
+  if printf '%s' "${issue_json}" | _jq -r '.labels[].name' 2>/dev/null | grep -q 'human-input-needed'; then
     printf 'blocked'
     return 0
   fi
@@ -187,27 +193,27 @@ format_duration() {
 
 log_batch_start() {
   local -r index="$1" total="$2" ticket="$3"
-  printf '[%s] [%s/%s] ▶ START %s\n' "$(_ts)" "${index}" "${total}" "${ticket}"
+  printf '[%s] [%s/%s] ▶ START %s\n' "$(_ts)" "${index}" "${total}" "${ticket}" >&2
 }
 
 log_batch_skip() {
   local -r index="$1" total="$2" ticket="$3" reason="$4"
-  printf '[%s] [%s/%s] ⊘ SKIP %s — %s\n' "$(_ts)" "${index}" "${total}" "${ticket}" "${reason}"
+  printf '[%s] [%s/%s] ⊘ SKIP %s — %s\n' "$(_ts)" "${index}" "${total}" "${ticket}" "${reason}" >&2
 }
 
 log_batch_done() {
   local -r index="$1" total="$2" ticket="$3" detail="$4" duration="$5"
-  printf '[%s] [%s/%s] ✓ DONE %s — %s (%s)\n' "$(_ts)" "${index}" "${total}" "${ticket}" "${detail}" "${duration}"
+  printf '[%s] [%s/%s] ✓ DONE %s — %s (%s)\n' "$(_ts)" "${index}" "${total}" "${ticket}" "${detail}" "${duration}" >&2
 }
 
 log_batch_blocked() {
   local -r index="$1" total="$2" ticket="$3" detail="$4" duration="$5"
-  printf '[%s] [%s/%s] ⏸ BLOCKED %s — %s (%s)\n' "$(_ts)" "${index}" "${total}" "${ticket}" "${detail}" "${duration}"
+  printf '[%s] [%s/%s] ⏸ BLOCKED %s — %s (%s)\n' "$(_ts)" "${index}" "${total}" "${ticket}" "${detail}" "${duration}" >&2
 }
 
 log_batch_failed() {
   local -r index="$1" total="$2" ticket="$3" detail="$4" duration="$5"
-  printf '[%s] [%s/%s] ✗ FAILED %s — %s (%s)\n' "$(_ts)" "${index}" "${total}" "${ticket}" "${detail}" "${duration}"
+  printf '[%s] [%s/%s] ✗ FAILED %s — %s (%s)\n' "$(_ts)" "${index}" "${total}" "${ticket}" "${detail}" "${duration}" >&2
 }
 
 # PURE: Format the final batch summary line block
@@ -383,6 +389,15 @@ main() {
   [[ ${total} -gt 0 ]] || die "No tickets provided. See --help."
 
   log_info "Starting batch delivery of ${total} ticket(s)"
+  local _i
+  for ((_i = 0; _i < total; _i++)); do
+    local _t="${PARSED_TICKETS[$_i]}" _b="${PARSED_BRANCHES[$_i]}"
+    if [[ -n "${_b}" ]]; then
+      log_info "  $((_i + 1))/${total}: ${_t}:${_b}"
+    else
+      log_info "  $((_i + 1))/${total}: ${_t}"
+    fi
+  done
 
   run_batch
 }

--- a/scripts/deliver-ticket.sh
+++ b/scripts/deliver-ticket.sh
@@ -201,7 +201,7 @@ Nothing to do. Report "merged/closed" and STOP.
 1. Fetch all review comments: gh pr view <PR> --json comments,reviews,reviewDecision
 2. Check for approval signals (ANY ONE is sufficient to merge):
   a. GitHub-native APPROVED review: gh pr view <PR> --json reviewDecision -q '.reviewDecision' equals "APPROVED"
-  b. "approved" label on the ticket issue: gh issue view ${ticket_ref} --json labels -q '.labels[].name' | grep -qi approved
+  b. "approved" label on the ticket issue: gh issue view ${issue_num} --json labels -q '.labels[].name' | grep -qi approved
 ${lgtm_signal}
 3. If approved (any signal):
    - Squash-merge: gh pr merge <PR> --squash --delete-branch
@@ -224,7 +224,7 @@ ${lgtm_signal}
 5. Ensure the "approved" label exists for solo-developer approval: gh label create "approved" --color "0E8A16" --description "Approved for merge (solo-developer-friendly)" 2>/dev/null || true
 
 ### If technically blocked (missing credentials/access/tooling)
-1. Add label: gh issue edit ${ticket_ref} --add-label human-input-needed
+1. Add label: gh issue edit ${issue_num} --add-label human-input-needed
 2. Add comment explaining the blocker.
 3. Report "blocked" and STOP.
 

--- a/scripts/deliver-ticket.sh
+++ b/scripts/deliver-ticket.sh
@@ -88,13 +88,13 @@ trap '_on_interrupt' INT TERM
 # ============================================================================
 _ts() { date '+%H:%M:%S'; }
 
-log_info()   { printf '[%s] ℹ %s %s\n' "$(_ts)" "${LOG_TAG}" "$*"; }
+log_info()   { printf '[%s] ℹ %s %s\n' "$(_ts)" "${LOG_TAG}" "$*" >&2; }
 log_warn()   { printf '[%s] ⚠ %s %s\n' "$(_ts)" "${LOG_TAG}" "$*" >&2; }
 log_err()    { printf '[%s] ✗ %s %s\n' "$(_ts)" "${LOG_TAG}" "$*" >&2; }
-log_start()  { printf '[%s] ▶ START %s\n' "$(_ts)" "$*"; }
-log_done()   { printf '[%s] ✓ DONE %s\n' "$(_ts)" "$*"; }
+log_start()  { printf '[%s] ▶ START %s\n' "$(_ts)" "$*" >&2; }
+log_done()   { printf '[%s] ✓ DONE %s %s\n' "$(_ts)" "${LOG_TAG}" "$*" >&2; }
 log_failed() { printf '[%s] ✗ FAILED %s\n' "$(_ts)" "$*" >&2; }
-log_debug()  { [[ "${VERBOSE}" == "true" ]] && printf '[%s] ℹ DEBUG %s %s\n' "$(_ts)" "${LOG_TAG}" "$*" || true; }
+log_debug()  { [[ "${VERBOSE}" == "true" ]] && printf '[%s] ℹ DEBUG %s %s\n' "$(_ts)" "${LOG_TAG}" "$*" >&2 || true; }
 
 die() { log_err "$@"; exit "${EXIT_USAGE}"; }
 
@@ -138,6 +138,12 @@ validate_ticket_ref() {
   [[ "${ticket_ref}" =~ ^[A-Z]+-[0-9]+$ ]]
 }
 
+# PURE: Convert workItemRef (GH-37) to bare issue number (37) for gh CLI
+to_issue_number() {
+  local -r ticket_ref="$1"
+  printf '%s' "${ticket_ref#*-}"
+}
+
 # ============================================================================
 # PROMPT BUILDING
 # ============================================================================
@@ -147,6 +153,10 @@ build_delivery_prompt() {
   local -r branch="$2"
   local branch_hint=""
   [[ -n "${branch}" ]] && branch_hint=" (branch: ${branch})"
+
+  # gh issue view needs a bare issue number (37), not the workItemRef (GH-37).
+  local issue_num
+  issue_num="$(to_issue_number "${ticket_ref}")"
 
   # C-1: LGTM comment detection is opt-in (DELIVER_ALLOW_LGTM_COMMENT=true,
   # default false) and, when enabled, restricted to the PR author's comments
@@ -163,7 +173,7 @@ build_delivery_prompt() {
 Deliver ${ticket_ref} end-to-end using ADOS. Detect state at the top, then act.
 
 ## State Detection (run first, every time)
-1. Check GitHub: gh issue view ${ticket_ref} --json state,labelNames
+1. Check GitHub: gh issue view ${issue_num} --json state,labels
 2. Check for open PR: gh pr list --head ${branch:-<ticket-branch>} --state open --json number,title
 3. Check for merged PR: gh pr list --search "${ticket_ref}" --state closed --json mergedAt
 
@@ -448,7 +458,7 @@ classify_result() {
   local -r branch="$2"
 
   local issue_json issue_state
-  issue_json="$(_gh issue view "${ticket_ref}" --json state,labelNames 2>/dev/null)" || {
+  issue_json="$(_gh issue view "$(to_issue_number "${ticket_ref}")" --json state,labels 2>/dev/null)" || {
     # m-7: gh/network failure (rate limit, connectivity) — return "unknown" so
     # the loop retries without burning a restart slot.
     log_warn "Could not fetch issue state for ${ticket_ref} (network/rate-limit?)"
@@ -464,7 +474,7 @@ classify_result() {
   fi
 
   # Check for human-input-needed label
-  if printf '%s' "${issue_json}" | _jq -r '.labelNames[]?' 2>/dev/null | grep -q 'human-input-needed'; then
+  if printf '%s' "${issue_json}" | _jq -r '.labels[].name' 2>/dev/null | grep -q 'human-input-needed'; then
     printf 'blocked'
     return 0
   fi


### PR DESCRIPTION
Closes #129. Fixes 3 compounding bugs that completely prevent autonomous batch delivery from working.

## Bugs Fixed

**Bug 1: `gh issue view` uses unparseable ticket format**
`gh issue view "GH-37"` fails with `invalid issue format`. The `gh` CLI expects the bare number (`37`). Scripts passed `${ticket_ref}` (e.g. `GH-108`) directly. The `2>/dev/null` hid the real error; the script misclassified it as "network/rate-limit?".

Fix: Added `to_issue_number()` helper (`${ticket_ref#*-}`) used in all `gh issue view` calls.

**Bug 2: `--json state,labelNames` uses non-existent field**
`gh issue view` has no `labelNames` field. The correct field is `labels` (array of objects with `.name`). The `human-input-needed` label check never fired.

Fix: Changed to `--json state,labels` and `.labels[].name` in all jq queries.

**Bug 3: `log_info`/`log_start`/`log_done` pollute stdout (root cause of GH-126 fix not working)**
These functions printed to **stdout**. But `run_single_iteration()` is called with `$(...)`, capturing ALL stdout into `monitor_result`. The multi-line result broke ALL string comparisons (`== "finished"`, `== "stuck"`) — the GH-126 fix for `finished + unknown → stop` never triggered.

Fix: All log functions now write to stderr (`>&2`). `run_single_iteration()` stdout is clean — only the result string.

## Enhancement
`batch-deliver.sh` now logs the full ticket list at start for log readability.

## Tests
- `test-deliver-ticket.sh`: 39/39 (new TC-DT-02c `to_issue_number`)
- `test-batch-deliver.sh`: 16/16 (new TC-BD-03c; TC-BD-05 now correctly passes)
- Shellcheck: clean (severity=error)

Refs: GH-129